### PR TITLE
b-remaster: updates all jobs except wizard

### DIFF
--- a/core/revised/adept.tex
+++ b/core/revised/adept.tex
@@ -3,13 +3,13 @@
 
     \textbf{Representatives}: General Beatrix (FFIX), Agrias Oaks (FFT), Goffard Gafgarion (FFT), Dark Knight Job (FFX-2, FFXI), Fell Knight Job (FFT), Mystic Knight Job (FFV), Adelbert Steiner (FFIX), Warrior Dressphere (FFX-2) \pc
 
-    \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=1x,mpc=2x,armor=Heavy,weapons=Claws/Gloves \\ Heavy Weapons \& Sheids \\ Heavy Weapons \\ Katanas \\  Wands \\ Staves ]
+    \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=1x,mpb=2x,mpc=3x,armor=Heavy,weapons=Claws/Gloves \\ Weapons \& Shield \\ Heavy Weapons \\ Katanas \\  Wands \\ Staves ]
 \end{jobdesc}
 
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Martial Discipline}: Core Ability acquired at level 1. You are an adept, and gain the multipliers and equipment choices above. \pc
+\noindent\tability{Martial Discipline}: Core Ability acquired at level 1. You are an adept, and gain the multipliers and equipment choices above. Whenever you use an Adept ability, you may spend 10\%, 20\% or 30\% of your current HP to decrease the charge time by 2, 4 or 6, respectively. This can reduce the charge time a minimum of 0. The action modified by this ability becomes a magical action. \pc
 
 \begin{jobchoice}
 \crystal{fire}{12pt} & %
@@ -28,18 +28,18 @@
 \crystal{level}{12pt} & %
 \taction{Elemental Strike} is a Slow (1) \tatk{magical} action. To use it, choose \telem{Fire}, \telem{Lightning}, or \telem{Ice}. You concentrate the chosen element and strike a weapon attack causing normal damage, using the chosen element. \\
 \crystal{level}{12pt} & %
-\taction{Holy Strike} is a Quick \tatk{magical} action. Using your own vital energy as sacred power, you attack with the force of \telem{Light}. Spend 10\% of your max HP to attack with your weapon. Your attack deals 150\% weapon damage, \telem{Light}-elemental. \\
+\taction{Holy Strike} is a Slow (4) action. Using your own vital energy as sacred power, you attack with the force of \telem{Light}. Do a weapon attack dealing 150\% weapon damage, \telem{Light}-elemental. \\
 \crystal{level}{12pt} & %
-\taction{Shadow Strike} is a Quick \tatk{magic} action. Sacrificing your own life force to profane powers, you use the forces of \telem{Shadow} to attack. Spend 10\% of your max HP to attack with your weapon. Your attack deals 150\% weapon damage, \telem{Shadow}-elemental. \\
+\taction{Shadow Strike} is a Slow (4) action. Sacrificing your own life force to profane powers, you use the forces of \telem{Shadow} to attack. Do a weapon attack dealing 150\% weapon damage, \telem{Shadow}-elemental. \\
 \end{jobchoice}
 
 \begin{jobchoice}
 \crystal{air}{12pt} \crystal{water}{12pt} & %
 \tspec{Dualism}: Requires Air and Water level 5. You gain one of the following actions: \taction{Elemental Strike}, \taction{Holy Strike} or \taction{Shadow Strike}. \\
-\crystal{water}{12pt} & %
-\tspec{Spirit Strength}: Requires Water level 3. Whenever you need to spend HP to use an action, you may spend an equal amount of MP to prevent the HP loss. \\
-\crystal{earth}{12pt} & %
-\tspec{Arcane Fury}: Requires Earth level 3. While your current MP is greater than zero and you have the \tstatus{Berserk} status, your \taction{Attack} action deal 150\% weapon damage. \\
+\crystal{earth}{12pt} \crystal{air}{12pt} & %
+\tspec{Will Shield}: Requires Earth level 6 and Air level 4. You gain the reaction \taction{Will Shield}. You can use this reaction whenever you suffer damage. Conjuring up a protective magical shield, you avoid injuries. Perform a Water vs (the greater of Earth or Fire) attack, difficulty 30. If successful, negate all effects of the attack and spend MP equal 10\% of your maximum MP. If you do not have enough MP to spend, this ability fails. \\
+\crystal{fire}{12pt} & %
+\tspec{Quick Channeling}: Requires Fire level 7. When using an ability, you may reduce its charge time by 1, to a minimum of 0. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -48,33 +48,33 @@
 
 \begin{jobchoice}[header=false]
 \crystal{level}{12pt} & %
-\taction{Snake Fang} is a Ranged Slow (1) \tatk{magical} action. Spend 10\% of your max HP to create a snake-shaped wave of energy. The snake then attacks a target of your choice, a Fire vs Earth attack, difficulty 40. If successful, the target suffers \telem{Bio}-elemental weapon damage, and the \tstatus{Poison} status until the end of next round. \\
+\taction{Snake Fang} is a Ranged Slow (2) \tatk{magical} action. You create a snake-shaped wave of energy. The snake then attacks a target of your choice, a Fire vs Earth attack, difficulty 40. If successful, the target suffers \telem{Bio}-elemental weapon damage, and the \tstatus{Poison} status until the end of next round. \\
 \crystal{level}{12pt} & %
-\taction{Hallowed Bolt} is a Ranged Slow (1) \tatk{magical} action. Spend 10\% of your max HP to create a luminous energy sphere. You send that ball spiraling against a target of your choice, a Fire vs Fire attack, difficulty 40. If successful, the target suffers \telem{Lightning}-elemental weapon damage, and the \tstatus{Mute} status until the end the next round. \\
+\taction{Hallowed Bolt} is a Ranged Slow (2) \tatk{magical} action. You create a luminous energy sphere, then send that ball spiraling against a target of your choice, a Fire vs Fire attack, difficulty 40. If successful, the target suffers \telem{Lightning}-elemental weapon damage, and the \tstatus{Curse} status until the end the next round. \\
 \crystal{level}{12pt} & %
-\taction{Black Sky} is a Ranged Slow (1) \tatk{magical} action. Spend 10\% of your max HP to invoke a black energy beam from the sky. The lightning strikes a target of your choice, a Fire vs Air attack, difficulty 40. If successful, the target suffers \telem{Shadow}-elemental weapon damage, and the \tstatus{Blind} status until the end of next round. \\
+\taction{Black Sky} is a Ranged Slow (2) \tatk{magical} action. You invoke a black energy beam from the sky. The lightning strikes a target of your choice, a Fire vs Air attack, difficulty 40. If successful, the target suffers \telem{Shadow}-elemental weapon damage, and the \tstatus{Blind} status until the end of next round. \\
 \end{jobchoice}
 
 \begin{jobchoice}
 \crystal{air}{12pt} \crystal{fire}{12pt} & %
-\tspec{Shadow Blade}: Requires Air level 6 and Fire level 9. You earn the Quick \tatk{magical} action \taction{Shadow Blade}. Conjuring a tornado of souls, perform a weapon attack against all other combatants, enemies and allies. You deal 150\% weapon damage, \telem{Shadow}-elemental, to all characters hit. \\
+\tspec{Shadow Blade}: Requires Air level 6 and Fire level 9. You earn the Slow (2) \tatk{magical} action \taction{Shadow Blade}. Conjuring a tornado of souls, perform a weapon attack against all other combatants, enemies and allies. You deal 150\% weapon damage, \telem{Shadow}-elemental, to all characters hit. \\
 \crystal{earth}{12pt} \crystal{air}{12pt} & %
-\tspec{Stasis Strike}: Requires Earth level 9 and Air level 6. You gain the Ranged Quick \tatk{magical} action \taction{Stasis Strike}. Spend 25\% of your current HP to summon a lightning bolt from heavens. If you are successful in a weapon attack, deal 150\% weapon damage, \telem{Light}-elemental, and inflict the \tstatus{Immobilize} status until the end of your next round on a target. \\
+\tspec{Stasis Strike}: Requires Earth level 9 and Air level 6. You gain the Ranged Slow (5) action \taction{Stasis Strike}. You summon a lightning bolt from heavens. If you are successful in a weapon attack, difficulty 30, deal 150\% weapon damage, \telem{Light}-elemental, to a target. If your attack is a critical hit or overcomes difficulty 70, inflict the \tstatus{Immobilize} status until the end of your next round on the target. \\
 \crystal{air}{12pt} \crystal{water}{12pt} & %
-\tspec{Fury Brand}: Requires Air level 6 and Water level 9. You gain the Quick \tatk{magical} action \taction{Fury Brand}. Spend 25\% of your current HP to create a rune of fury in your weapon and strike. If you are successful in a weapon attack, deal 150\% weapon damage, \telem{Fire}-elemental, and inflict the \tstatus{Berserk} status until the end of your next round on a target. \\
+\tspec{Fury Brand}: Requires Air level 6 and Water level 9. You gain the Quick \tatk{magical} action \taction{Fury Brand}. Create a rune of fury in your weapon and strike. If you are successful in a weapon attack, difficulty 30, deal 150\% weapon damage, \telem{Fire}-elemental, to a target. If your attack is a critical hit or overcomes difficulty 70, inflict the \tstatus{Mute} status until the end of your next round on the target. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Elemental Soul}: Core Ability acquired at level 24. Select \telem{Fire}, \telem{Ice}, \telem{Lightning}, \telem{Light}, or \telem{Shadow}. You become \tstatus{Immune} to all damage of the chosen element. \pc
+\noindent\tability{Elemental Soul}: Core Ability acquired at level 24. Select an element other than \telem{Cut}, \telem{Crush} or \telem{Puncture}. You become \tstatus{Immune} to all damage of the chosen element. In addition, choose one of the following actions to augment: Reduce \taction{Will Shield}'s difficulty to 10, \taction{Stasis Strike} may inflict \tstatus{Stop} instead of \tstatus{Immobilize}, \taction{Fury Brand} may inflict \tstatus{Berserk} instead of \tstatus{Mute} or \taction{Cleansing Strike} may inflict \tstatus{Toad} instead of \tstatus{Disable}. \pc
 
 \begin{jobchoice}
 \crystal{fire}{12pt} & %
-\tspec{Night Sword}: Requires Fire level 13. You gain the Slow (3) \tatk{magical} action \taction{Night Sword.} Using dark energies in your favor, you drain the life energy of your target. Spend 10\% of your current HP to attack with your weapon. If successful, deal weapon damage, \telem{Shadow}-elemental, and you heal HP equal to the damage dealt, after reducing by MARM. \\
-\crystal{water}{12pt} & %
-\tspec{Light's Judgement}: Requires Water level 13. You gain the Slow (3) \tatk{magical} action \taction{Cleansing Strike}. This action creates an arcane seal in the air, at the cost of 25\% of your current HP. You then attack a target with your weapon, destroying the seal and dealing 150\% weapon damage, \telem{Ice}-elemental, and the \tstatus{Disable} status to a until the end of next round. \\
+\tspec{Night Sword}: Requires Fire level 10. You gain the Slow (2) action \taction{Night Sword.} Using dark energies in your favor, you drain the life energy of your target. Attack with your weapon to deal weapon damage, \telem{Shadow}-elemental, to a target, and you heal HP equal to the damage dealt, after reducing by ARM or MARM. \\
 \crystal{earth}{12pt} & %
-\tspec{Reckless Sacrifice}: Requires Earth level 13. When using an Adept \tatk{action} that inflicts a negative status on a single target, you can choose to automatically hit without performing an attack roll. If you do, you suffer the same status for the same duration. \\
+\tspec{Light's Judgement}: Requires Earth level 10. You gain the Slow (5) action \taction{Cleansing Strike}. This action creates an arcane seal in the air, and then you attack a target with your weapon, destroying the seal and dealing 150\% weapon damage, \telem{Ice}-elemental. If your attack is a critical hit or overcomes difficulty 70, inflict the \tstatus{Disable} status until the end of your next round on the target. \\
+\crystal{water}{12pt} & %
+\tspec{Reckless Sacrifice}: Requires Water level 10. When using an Adept \tatk{action} that inflicts a negative status on a single target, you can choose to automatically hit without performing an attack roll. If you do, you inflict the status on the target and on yourself for the same duration. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -84,27 +84,27 @@
 }
 \end{center}
 \begin{ffminipage}
-\noindent\tability{Arcane Shock}: Core Ability acquired at level 42. You gain the Ranged Slow (3) \tatk{magical} action \taction{Demi Shock}. Concentrating the arcane forces, you try to break the enemy. Do a Fire vs Earth attack, difficulty 70. If successful, the target loses 50\% of their current HP. This counts as a \tstatus{Gravity}-type status effect. \pc
+\noindent\tability{Arcane Shock}: Core Ability acquired at level 42. You gain the Ranged Slow (3) \tatk{magical} action \taction{Demi Shock}. Concentrating the arcane forces, you try to break the enemy. Do a Fire vs Earth attack, difficulty 40. If successful, the target loses 50\% of their current HP. This counts as a \tstatus{Gravity}-type status effect. \pc
 
 \begin{jobchoice}
 \crystal{earth}{12pt} \crystal{water}{12pt} & %
 \tspec{Mana Safe}: Requires Earth level 8 and Water level 10. You can spend any amount of MP and an action to heal the same amount of MP to an ally. Any ally can spend any amount of MP and an action to heal on you half that amount of MP. \\
 \crystal{earth}{12pt} \crystal{fire}{12pt} & %
-\tspec{Dark Pact}: Requires Earth and Fire level 11. Whenever you spend HP to use an Adept action that deals \telem{Shadow}-elemental damage, you may spend extra 10\% of your max HP to deal extra 50\% weapon damage. You must declare this Ability before rolling the attack, spending the extra HP regardless of hitting or missing. \\
+\tspec{Dark Pact}: Requires Earth and Fire level 11. Whenever you spend HP to use a Quick Adept action that deals \telem{Shadow}-elemental damage, you may spend extra 10\% of your max HP to deal extra 50\% weapon damage. You must declare this Ability before rolling the attack, spending the extra HP regardless of hitting or missing. \\
 \crystal{air}{12pt} \crystal{fire}{12pt} & %
-\tspec{Elemental Overload}: Requires Air level 7 and Fire level 12. Whenever you spend HP to use an Adept action that deals \telem{Fire}-, \telem{Ice}- or \telem{Lightning}-elemental, you may double the HP spent to attack all opponents, rather than just one target. \\
+\tspec{Elemental Overload}: Requires Air level 7 and Fire level 12. Whenever you spend HP to use a Quick Adept action that deals \telem{Fire}-, \telem{Ice}- or \telem{Lightning}-elemental damage, you may spend extra 10\% of your max HP to attack all opponents, rather than just one target. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Staggering Blow}: Core Ability acquired at level 60. Whenever you damage a target preparing a Slow action with an action, you can reduce the damage dealt by half to make the target lose the prepared action. \pc
+\noindent\tability{Staggering Blow}: Core Ability acquired at level 60. Whenever one of your abilities damage a charging target, the target loses the Slow action. \pc
 
 \begin{jobchoice}
 \crystal{earth}{12pt} & %
-\tspec{Shellburst Stab}: Requires Earth level 20. You gain the Ranged Quick \tatk{magical} action \taction{Shellburst Stab}. You overload the target with magical energy. Spend 10\% of your max HP to perform an Earth vs Water attack, difficulty 40. If successful, the target takes \telem{Puncture}-elemental damage equal to the lesser between its current MP or 999. \\
+\tspec{Shellburst Stab}: Requires Earth level 20. You gain the Ranged Slow (6) \tatk{magical} action \taction{Shellburst Stab}. You overload the target with magical energy. Perform an Earth vs Water attack, difficulty 40, to deal \telem{Puncture}-elemental damage equal to the lesser between the target's current MP or 999. \\
 \crystal{air}{12pt} & %
-\tspec{Soul Eater}: Requires Air level 20. You gain the Ranged Quick \tatk{magical} action \taction{Soul Eater}. Opening a portal to the underworld, you try to drag their opponents into eternal sleep. Spend 25\% of your max HP and do a weapon attack against all enemies, difficulty 40. All opponents hit are reduced to 0 HP. Treat this as a \tstatus{Fatal} type status. If any of the targets is immune to this effect, you deal 150\% weapon damage to it, \telem{Shadow}-elemental. \\
+\tspec{Soul Eater}: Requires Air level 20. You gain the Ranged Slow (6) action \taction{Soul Eater}. Opening a portal to the underworld, you try to drag their opponents into eternal sleep. Do a weapon attack against all enemies, difficulty 50. All opponents hit are reduced to 0 HP. Treat this as a \tstatus{Fatal} type status. If any of the targets is immune to this effect, you deal 150\% weapon damage to it, \telem{Shadow}-elemental. \\
 \crystal{water}{12pt} & %
-\tspec{Divine Ruination}: Requires Water level 20. You gain the Ranged Quick magical action \tability{Divine Ruination}. You show the light of glory to your opponents, who are tempted to follow you. Spend 25\% of your max HP and do a weapon attack against all enemies, difficulty 40. All opponents hit receive the \tstatus{Charm} status. If any of the targets is immune to this effect, you deal 150\% weapon damage to it, \telem{Light}-elemental. \\
+\tspec{Divine Ruination}: Requires Water level 20. You gain the Ranged Slow (6) action \taction{Divine Ruination}. You show the light of glory to your opponents, who are tempted to follow you. Do a weapon attack against all enemies, difficulty 50. All opponents hit receive the \tstatus{Charm} status. If any of the targets is immune to this effect, you deal 150\% weapon damage to it, \telem{Light}-elemental. \\
 \end{jobchoice} 
 \end{ffminipage}

--- a/core/revised/alchemist.tex
+++ b/core/revised/alchemist.tex
@@ -7,7 +7,7 @@
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Quick Hands}: Core Ability acquired at level 1. \taction{Draw} is a free action for you. You still need to spend initiative dice normally to use items or replace equipment. \pc
+\noindent\tability{Quick Hands}: Core Ability acquired at level 1. Once per phase, you may use the \taction{Draw} as a free action when you use \taction{Item}. \pc
 
 \begin{jobchoice}
 \crystal{fire}{12pt} & %
@@ -39,7 +39,7 @@
 \crystal{fire}{12pt} & %
 \tspec{Mix}: Requires Fire level 16. You gain the Slow (1) action \taction{Mix}. You can mix two items and use them in a single action. If mixing two identical healing items, you generate the effect of the next higher-level item (for example, two \titem{Potions} turn into a \titem{Hi-Potion}). If you mix two different healing items, you generate the effect of the cheapest item in the whole Group (Mixing a \titem{Soft} and \titem{Tonic} creates the effect of Tonic in the Group). If you mix two identical battle items, you cast the next strongest Spell of the same group (two \titem{Bomb Fragment} cast the Spell \tspell{Fira}). If you mix two different battle items, you cast the Spell from the cheapest item against a Group (using the single target damage if the spell deals reduced damage to groups). Special cases may be examined individually by the GM and cause unique effects. \\
 \crystal{earth}{12pt} \crystal{water}{12pt} & %
-\tspec{Alchemical Tenacity}: Requires Earth and Water level 14. Increase your HP bonus by 1x your level and your MP bonus by 1x your level. \\
+\tspec{Alchemical Tenacity}: Requires Earth and Water level 14. Increase your HP and MP bonus multipliers by 1 each at all levels. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -48,7 +48,7 @@
 
 \begin{jobchoice}
 \crystal{air}{12pt} & %
-\tspec{Double Item}: Requires Air level 18. You gain the Quick action \taction{W-Item}. With it, you may use two drawn items with only one action. \\
+\tspec{Double Item}: Requires Air level 18. You gain the Quick action \taction{W-Item}. With it, you draw and use up to two items with only one action. \\
 \crystal{earth}{12pt} & %
 \tspec{Auto-Potion}: Requires Earth level 18. You gain the reaction \taction{Auto-Potion}. You can use it when you suffer an attack. You draw an item from your inventory and use it on yourself. The item’s effects happen after the effects of the attack you suffered. \\
 \end{jobchoice}

--- a/core/revised/archer.tex
+++ b/core/revised/archer.tex
@@ -10,102 +10,84 @@
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\textbf{\textit{Sharpshooter}}: Core Ability acquired at level 1. You are an archer, and gain the multipliers and equipment choices above.
+\tability{Sharpshooter}: Core Ability acquired at level 1. You are an archer, and gain the multipliers and equipment choices above.
 
 
 \begin{jobchoice}
 \crystal{fire}{12pt} & %
-\textit{Precise Shot}: Requires Fire level 3. Whenever you attack with a rifle or crossbow, all reactions to your attack use Fire as a Defensive Stat instead of the original Defensive Stat. For example, if someone tries to \textbf{!Dodge} your attack, instead of rolling Air vs Earth as normal, the enemy will roll Air vs Fire. \\
+\tspec{Precise Shot}: Requires Fire level 3. Whenever you attack with a rifle or crossbow, all reactions to your attack use Fire as a Defensive Stat instead of the original Defensive Stat. For example, if someone tries to \taction{Dodge} your attack, instead of rolling Air vs Earth as normal, the enemy will roll Air vs Fire. \\
 \crystal{earth}{12pt} & %
-\textit{Quick Throw}: Requires Earth level 5. Whenever you attack with a Throwing Weapon, you may re-roll the attack once. \\
+\tspec{Quick Throw}: Requires Earth level 5. Whenever you attack with a Throwing Weapon, you may re-roll the attack once. \\
 \crystal{water}{12pt} & %
-\textit{Point Blank}: Requires Water level 3. Whenever you attack with your weapon, you may declare a point-blank shot. If you do, your weapon is not Ranged during this attack. \\
+\tspec{Point Blank}: Requires Water level 3. Whenever you declare an attack with a Ranged weapon, you may declare a point-blank shot to reduce the charge time of the attack by 1, to a minimum of 0. Your weapon is not Ranged during this attack. \\
+\crystal{air}{12pt} & %
+\tspec{Warning Volley}: Requires Air level 4. Whenever you declare an attack with a Bow, you may increase its charge time by 1 to shot a warning volley. In addition to the attack's effects, you deal weapon damage to all enemies that react to the attack other than the original target. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\textbf{\textit{Arcane Discipline}}: Core Ability acquired at level 1. You earn one of the three following actions:
-
-\begin{jobchoice}[header=false]
-\crystal{level}{12pt} & %
-\textbf{!Elemental Strike} is a Slow (1) magical action. To use it, choose Fire, Lightning or Ice. You concentrate the chosen element and strike a weapon attack causing normal damage, using the chosen element. \\
-\crystal{level}{12pt} & %
-\textbf{!Holy Strike} is a Quick magical action. Using your own vital energy as sacred power, you attack with the force of Light. Spend 10\% of your max HP to attack with your weapon. Your attack deals 150\% weapon damage, Light-elemental. \\
-\crystal{level}{12pt} & %
-\textbf{!Shadow Strike} is a Quick magic action. Sacrificing your own life force to profane powers, you use the forces of Shadow to attack. Spend 10\% of your max HP to attack with your weapon. Your attack deals 150\% weapon damage, Shadow-elemental. \\
-\end{jobchoice}
+\noindent\tability{Charge}: Core Ability acquired at level 1. You gain the Slow (3) action \taction{Charge}. You aim for an accurate shot. Attack with your weapon, dealing 150\% weapon damage.
 
 \begin{jobchoice}
-\crystal{air}{12pt} \crystal{water}{12pt} & %
-\textit{Dualism}: Requires Air and Water level 5. You gain one of the following actions: \textbf{!Elemental Strike}, \textbf{!Holy Strike} or \textbf{!Shadow Strike}. \\
 \crystal{water}{12pt} & %
-\textit{Spirit Strength}: Requires Water level 3. Whenever you need to spend HP to use an action, you may spend an equal amount of MP to prevent the HP loss. \\
-\crystal{earth}{12pt} & %
-\textit{Arcane Fury}: Requires Earth level 3. While your current MP is greater than zero and you have the \textbf{Berserk} status, your \textbf{!Attack} action deal 150\% weapon damage. \\
-\end{jobchoice}
-\end{ffminipage}
-
-\begin{ffminipage}
-\noindent\textbf{\textit{Blade Magic}}: Core Ability acquired at level 15. You gain one of the three following actions:
-
-\begin{jobchoice}[header=false]
-\crystal{level}{12pt} & %
-\textbf{!Snake Fang} is a Ranged Slow (1) magical action. Spend 10\% of your max HP to create a snake-shaped wave of energy. The snake then attacks a target of your choice, a Fire vs Earth attack, difficulty 40. If successful, the target suffers Bio-elemental weapon damage, and the Poison status until the end of next round. \\
-\crystal{level}{12pt} & %
-\textbf{!Hallowed Bolt} is a Ranged Slow (1) magical action. Spend 10\% of your max HP to create a luminous energy sphere. You send that ball spiraling against a target of your choice, a Fire vs Fire attack, difficulty 40. If successful, the target suffers Lightning-elemental weapon damage, and the Mute status until the end the next round. \\
-\crystal{level}{12pt} & %
-\textbf{!Black Sky} is a Ranged Slow (1) magical action. Spend 10\% of your max HP to invoke a black energy beam from the sky. The lightning strikes a target of your choice, a Fire vs Air attack, difficulty 40. If successful, the target suffers Shadow-elemental weapon damage, and the Blind status until the end of next round. \\
-\end{jobchoice}
-
-\begin{jobchoice}
+\tspec{Ambush}: Requires Water level 7. Until the end of the first round of each combat, your Stats count as two levels higher for damage calculation. \\
 \crystal{air}{12pt} \crystal{fire}{12pt} & %
-\textit{Shadow Blade}: Requires Air level 6 and Fire level 9. You earn the Quick magical action \textbf{!Shadow Blade}. Conjuring a tornado of souls, perform a weapon attack against all other combatants, enemies and allies. You deal 150\% weapon damage, Shadow- elemental, to all characters hit. \\
-\crystal{earth}{12pt} \crystal{air}{12pt} & %
-\textit{Stasis Strike}: Stasis Strike: Requires Earth level 9 and Air level 6. You gain the Ranged Quick magical action \textbf{!Stasis Strike}. Spend 25\% of your current HP to summon a lightning bolt from heavens. If you are successful in a weapon attack, deal 150\% weapon damage, Light-elemental, and inflict the Immobilize status until the end of your next round on a target. \\
-\crystal{air}{12pt} \crystal{water}{12pt} & %
-\textit{Fury Brand}: Requires Air level 6 and Water level 9. You gain the Quick magical
-action \textbf{!Fury Brand}. Spend 25\% of your current HP to create a rune of fury in your
-weapon and strike. If you are successful in a weapon attack, deal 150% weapon damage,
-Fire-elemental, and inflict the Berserk status until the end of your next round on a target. \\
+\tspec{Ungarmax}: Requires Air and Fire level 8. You gain the Slow (7) action \taction{Great Charge}. Elite hunters learn to wait for the perfect moment to shoot. Attack with your weapon, dealing 250\% weapon damage. \\
+\crystal{earth}{12pt} \crystal{water}{12pt} & %
+\tspec{Reflex Shot}: Requires Earth level 7 and Water level 9. You gain the interrupt \taction{Reflex Shot}. It may be used when you are targeted by an attack while charging. Attack with your weapon, causing normal damage and applying all equipment effects. This ability may achieve critical hits, causing double damage.\\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\textbf{\textit{Elemental Soul}}: Core Ability acquired at level 24. Select Fire, Ice, Lightning, Light or Shadow. You become Immune to all damage of the chosen element.
-
-\begin{jobchoice}
-\crystal{fire}{12pt} & %
-\textit{Night Sword}: Requires Fire level 13. You gain the Slow (3) magical action \textbf{!Night Sword.} Using dark energies in your favor, you drain the life energy of your target. Spend 10\% of your current HP to attack with your weapon. If successful, deal weapon damage, Shadow-elemental, and you heal HP equal to the damage dealt, after reducing by MARM. \\
-\crystal{water}{12pt} & %
-\textit{Light's Judgement}: Requires Water level 13. You gain the Slow (3) magical action \textbf{!Cleansing Strike}. This action creates an arcane seal in the air, at the cost of 25\% of your current HP. You then attack a target with your weapon, destroying the seal and dealing 150\% weapon damage, Ice-elemental, and the Disable status to a until the end of next round. \\
-\crystal{earth}{12pt} & %
-\textit{Reckless Sacrifice}: Requires Earth level 13. When using an Adept action that inflicts a negative status on a single target, you can choose to automatically hit without performing an attack roll. If you do, you suffer the same status for the same duration. \\
-\end{jobchoice}
-\end{ffminipage}
-
-\begin{ffminipage}
-\noindent\textbf{\textit{Arcane Shock}}: Core Ability acquired at level 42. You gain the Ranged Slow (3) magical action \textbf{!Demi Shock}. Concentrating the arcane forces, you try to break the enemy. Do a Fire vs Earth attack, difficulty 70. If successful, the target loses 50\% of their current HP. This counts as a \textbf{Gravity}-type status effect.
+\noindent\tability{Nutcracker}: Core Ability acquired at level 15. You gain the Slow (3) action \taction{Vitals Aim}. Aiming at your opponent’s weak points, attack with your weapon, dealing normal damage but ignoring the target's Armor and Magical Armor.
 
 \begin{jobchoice}
 \crystal{earth}{12pt} \crystal{water}{12pt} & %
-\textit{Mana Safe}: Requires Earth level 8 and Water level 10. You can spend any amount of MP and an action to heal the same amount of MP to an ally. Any ally can spend any amount of MP and an action to heal on you half that amount of MP. \\
-\crystal{earth}{12pt} \crystal{fire}{12pt} & %
-\textit{Dark Pact}: Requires Earth and Fire level 11. Whenever you spend HP to use an Adept action that deals Shadow-elemental damage, you may spend extra 10\% of your max HP to deal extra 50\% weapon damage. You must declare this Ability before rolling the attack, spending the extra HP regardless of hitting or missing. \\
+\tspec{Arm Aim}: Requires Earth level 8 and Water level 6. You gain the Slow (2) action \taction{Arm Aim}. You may use it to disable the target’s upper body. Attack with your weapon, difficulty 70. If successful, inflict the \tstatus{Disable} status on the target until the end of the next round. \\
+\crystal{earth}{12pt} \crystal{air}{12pt} & %
+\tspec{Leg Aim}: Requires Earth level 5 and Air level 9. You gain the Slow (2) action \taction{Leg Aim}. It disables the target’s lower members. Attack with your weapon, difficulty 70. If successful, inflict the \tstatus{Immobilize} status on the target until the end of the next round. \\
 \crystal{air}{12pt} \crystal{fire}{12pt} & %
-\textit{Elemental Overload}: Requires Air level 7 and Fire level 12. Whenever you spend HP to use an Adept action that deals Fire-, Ice- or Lightning-elemental, you may double the HP spent to attack all opponents, rather than just one target. \\
+\tspec{Head Aim}: Requires Air level 7 and Fire level 9. You gain the Slow (2) action \taction{Head Aim}. With it, you do a glancing shot on the head that causes disorientation and dizziness on target. Attack with your weapon, difficulty 70. If successful, inflict the \tstatus{Slow} status on the target over the next two rounds. \\
+\crystal{earth}{12pt} \crystal{fire}{12pt} & %
+\tspec{Eye Aim}: Requires Earth level 8 and Fire level 5. You gain the Slow (2) action \taction{Eye Aim}. You may use it to attack the target’s eyes. Attack with your weapon, difficulty 70. If successful, inflict the \tstatus{Blind} status on the target until the end of the next round. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\textbf{\textit{Staggering Blow}}: Core Ability acquired at level 60. Whenever you damage a target preparing a Slow action with an action, you can reduce the damage dealt by half to make the target lose the prepared action.
+\noindent\tability{Mindblow}: Core Ability acquired at level 24. You gain the Quick action \taction{Mindblow}, a mystic shot that drains the target’s energy. Attack with your weapon, causing normal damage, but decreasing the target’s MP instead of HP. This ability may critical hit, dealing double damage.
 
 \begin{jobchoice}
-\crystal{earth}{12pt} & %
-\textit{Shellburst Stab}: Requires Earth level 20. You gain the Ranged Quick magical action \textbf{!Shellburst Stab}. You overload the target with magical energy. Spend 10\% of your max HP to perform an Earth vs Water attack, difficulty 40. If successful, the target takes Puncture-elemental damage equal to the lesser between its current MP or 999. \\
-\crystal{air}{12pt} & %
-\textit{Soul Eater}: Requires Air level 20. You gain the Ranged Quick magical action \textbf{!Soul Eater}. Opening a portal to the underworld, you try to drag their opponents into eternal sleep. Spend 25\% of your max HP and do a weapon attack against all enemies, difficulty 40. All opponents hit are reduced to 0 HP. Treat this as a Fatal type status. If any of the targets is immune to this effect, you deal 150\% weapon damage to it, Shadow-elemental. \\
+\crystal{air}{12pt} \crystal{fire}{12pt} & %
+\tspec{Patience Shot}: Requires Air and Fire level 10. When using a damage-dealing action thats not a Spell, you can increase its charge time by 4 to increase the damage dealt by 50\% weapon damage. \\
 \crystal{water}{12pt} & %
-\textit{Divine Ruination}: Requires Water level 20. You gain the Ranged Quick magical
-action \textbf{!Divine Ruination}. You show the light of glory to your opponents, who are tempted to follow you. Spend 25\% of your max HP and do a weapon attack against all enemies, difficulty 40. All opponents hit receive the Charm status. If any of the targets is immune to this effect, you deal 150\% weapon damage to it, Light-elemental. \\
+\tspec{Marked Quarry}: Requires Water level 13. Requires Water level 13. Once per round, when you hit a single target attack, reduce the difficulty of the next attack targeting the same character by 30, to a minimum of 0. \\
+\crystal{earth}{12pt} \crystal{air}{12pt} & %
+\tspec{Wing Aim}: Requires Earth level 6 and Air level 10. You gain the Slow (1) action \taction{Wing Aim}. Using it, you shoot the target’s wings. Attack with your weapon, difficulty 70. If successful, the target loses the \tstatus{Float} and \tstatus{Flight} statuses, if any, and cannot gain them until the end of the next round. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+\noindent\tability{Danger Sense}: Core Ability acquired at level 42. You're always under the effects of \tstatus{Strengthen (Speed)} status. 
+
+\begin{jobchoice}
+\crystal{earth}{12pt} \crystal{air}{12pt} \crystal{fire}{12pt} & %
+\tspec{Deadly Precision}: Requires Earth, Air and Fire level 10. Your \taction{Arm Aim}, \taction{Leg Aim}, \taction{Head Aim}, \taction{Eye Aim}, \taction{Wing Aim} and \taction{Triple Foul} actions deal damage equal to 75\% weapon damage in addition to its effects. \\
+\crystal{water}{12pt} & %
+\tspec{Toolbox}: Requires Water level 8. You gain one of the following Specialties: \tspec{Arm Aim}, \tspec{Leg Aim}, \tspec{Head Aim}, \tspec{Eye Aim} or \tspec{Aim Wing}, even if you haven’t met the requirements and even if you already chose a Specialty for \tspec{Nutcracker} and/or \tspec{Mind Strike}. \\
+\crystal{earth}{12pt} & %
+\tspec{Colossus Slayer}: Requires Earth level 15. When you use the action \taction{Vitals Aim}, rather than ignore the target's Armor or Magical Armor, you add it to the damage dealt instead of subtracting it. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+\noindent\tability{Always Prepared}: Core Ability acquired at level 60. Choose any Specialty from any other Archer Ability. You gain this Specialty, even if you have chosen another Specialty for this Ability, and even if you haven’t met the requirements
+
+\begin{jobchoice}
+\crystal{air}{12pt} & %
+\tspec{Barrage}: Requires Air level 20. You gain the physical Slow (6) action \taction{Barrage}. Using it, attack with your weapon, difficulty 10, against a random enemy. This attack doesn't consider neither yours neither the target’s Stats. If you hit, inflict weapon damage and you may repeat the attack against a random enemy, this time with difficulty 20. As long as you keep hitting, you can repeat the attack, always adding 10, cumulatively, to the difficulty, until the difficulty becomes 100 or you miss an attack. This action can’t be used to start Marked Quarry or benefit from it. \\
+\crystal{fire}{12pt} & %
+\tspec{Crippling Shot}: Requires Fire level 20. You gain the Slow (4) action \taction{Triple Foul}. This action is a weapon attack, difficulty 70. If successful, you inflict all the statuses you could inflict the following actions: \taction{Arm Aim}, \taction{Leg Aim}, \taction{Head Aim}, \taction{Eye Aim}, \taction{Wing Aim}, as if you had used them. You only inflict the statuses based on the Abilities you have. \\
+\crystal{earth}{12pt} & %
+\tspec{Projectile Rain}: Requires Earth level 20. Whenever your action or reaction reduce a target to 0 HP, you gain an extra initiative dice with a value equal to the current phase plus one. You can’t gain initiative die with value 11 or greater. \\
 \end{jobchoice}
 \end{ffminipage}

--- a/core/revised/archer.tex
+++ b/core/revised/archer.tex
@@ -3,7 +3,7 @@
 
     \textbf{Representatives}: Archer Job (FFIII, FFT, FFTA), Ranger Job (FFXI), Hunter Job (FFV, FFXI, FFTA), Sniper Job (FFTA), Mustadio Bunanza (FFT), Barret Wallace (FFVII) \pc
 
-    \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=1x,mpc=2x,armor=Medium,
+    \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=0x,mpc=1x,armor=Medium,
     weapons=Claws/Gloves \\ Bows \\ Rifles / Crossbows \\ Throwing Weapons]
 \end{jobdesc}
 

--- a/core/revised/artist.tex
+++ b/core/revised/artist.tex
@@ -1,10 +1,10 @@
 \begin{jobdesc}[name=pjob-artist]
-  For these free souls, all life is a stage on which they weave magic from the arts of dance and song and mimicry. Their main Stat is Water, but an Artist can find all four Stats useful. Their abilities vary greatly, each specializing in one of the three arts.\pc
+  For these free souls, all life is a stage on which they weave magic from the arts of dance, song and mimicry. Their main Stat is Water, but an Artist can find all four Stats useful. Their abilities vary greatly, each specializing in one of the three arts.\pc
 
   \textbf{Representatives}: Edward Chris van Muir (FFIV), Bard Job (FFIII, FFV, FFXI, FFT), Penelo (FFTA2), Dancer Job (FFV, FFT, FFXI), Songstress Dressphere (FFX-2), Gogo (FFVI), Mime Job (FFV, FFT).\pc
 
-  \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=0x,mpb=balls,mpc=1x,armor=Medium,
-    weapons=Claws / Gloves\\Light Swords / Knives\\Instruments\\Throwing Weapons]
+  \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=0x,mpb=1x,mpc=2x,armor=Medium,
+    weapons=Claws / Gloves \\ Light Swords / Knives \\ Instruments \\ Throwing Weapons]
 
 \end{jobdesc}
 
@@ -12,7 +12,7 @@
 \begin{ffminipage}
   {\centering \textbf{Abilities} \par{}}
 
-  \tability{Strength of Character}: Core ability acquired at level 1. You are an artist and gain the multipliers and equipment listed above\pc
+  \tability{Strength of Character}: Core ability acquired at level 1. You are an artist and gain the multipliers and equipment listed above. \pc
 
   \begin{jobchoice}
     \crystal{air}{12pt} & %
@@ -43,14 +43,14 @@
 
   \begin{jobchoice}
     \crystal{air}{12pt} & %
-    \tspec{Juggler}: Requires Air level 3. Gain the ability to use one of these weapon types: Staves, Heavy Weapons, Katanas, Polearms, or Wands. Gain the \actype[ranged=true] \taction{Throw}: You throw your weapon, even if it seems impossible! Perform a weapon attack with your equipped weapon or one from your inventory \review{Is \taction{Draw} required?} with Air as its offensive element, and deal 150\% damage (200\% on critical hit). The weapon is lost until the end of combat.\\
+    \tspec{Juggler}: Requires Air level 3. Gain the ability to use one of these weapon types: Staves, Heavy Weapons, Katanas, Polearms, or Wands. Gain the \actype[ranged=true] \taction{Throw}: You throw a weapon, even if it seems impossible! Choose your equipped weapon or \taction{Draw} a chosen weapon from your inventory, and perform an Air vs Air attack to deal 150\% weapon damage on a hit or 200\% on a critical hit. The weapon is lost until the end of combat.\\
 
     \crystal{fire}{12pt} & %
-    \tspec{Illusionist}: Requires Fire level 5. Your MP multiplier becomes 1x if not greater. In addition, you gain one of the following Spell groups: \tspellgroup{Images}, \tspellgroup{Transform}, \tspellgroup{Strengthen}, \tspellgroup{Flight}, \tspellgroup{Weaken}, or \tspellgroup{Purify}.\\
+    \tspec{Illusionist}: Requires Fire level 5. Increase your MP bonus multiplier at all levels by 1 if its level 1 value is zero. In addition, you gain one of the following Spell groups: \tspellgroup{Images}, \tspellgroup{Transform}, \tspellgroup{Strengthen}, \tspellgroup{Flight}, \tspellgroup{Weaken}, or \tspellgroup{Purify}.\\
 
     \crystal{earth}{12pt}
     \crystal{air}{12pt} & %
-    \tspec{Legendary Tale}: Requires Earth and Air level 3. You gain the free \actype{reaciton=true, free=true} \taction{Legend}: Once per round, when an ally is successful at an action, you can roll 1d10. If you roll a 1, the ally's action fails. If you roll a 9 or 10, the ally's action becomes a critical hit.\\
+    \tspec{Legendary Tale}: Requires Earth and Air level 3. You gain the free \actype{reaction=true, free=true} \taction{Legend}: Once per round, when an ally is successful at an action, you can roll 1d10. If you roll a 1 or 2, the ally's action fails. If you roll 7 or greater, the ally's action becomes a critical hit.\\
   \end{jobchoice}
 \end{ffminipage}
 
@@ -61,10 +61,10 @@
   \begin{jobchoice}
     \crystal{fire}{12pt}
     \crystal{water}{12pt} & %
-    \tspec{Eclectic Artist}: Requires Fire level 8 and Water level 10. Choose \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use first level performances of the chosen type even without the required action.\\
+    \tspec{Eclectic Artist}: Requires Fire level 8 and Water level 10. Choose one first level \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use it as if you had chosen it as your \tability{Artistic Niche}. \\
 
     \crystal{earth}{12pt} & %
-    \tspec{Phlegm}: Requires Earth level 12. Whenever you are hit by an action that inflicts a negative status, its effects and duration don't begin until the start of the next round. This Specialty does not affect damage taken.\\
+    \tspec{Phlegm}: Requires Earth level 12. Whenever you are hit by an action that inflicts a negative status, you may choose to have its effects and duration begin at the start of the next round. This Specialty does not affect damage taken.\\
 
     \crystal{air}{12pt}
     \crystal{water}{12pt} & %
@@ -80,7 +80,7 @@
     \crystal{earth}{12pt}
     \crystal{air}{12pt}
     \crystal{water}{12pt} & %
-    \tspec{Perfectionism}: Requires Earth, Air and Water level 9. Choose \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use second level performances of the chosen type even without the required action.\\
+    \tspec{Perfectionism}: Requires Earth, Air and Water level 9. Choose one second level \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use it as if you had chosen it as your \tability{Artistic Niche}. \\
 
     \crystal{fire}{12pt}
     \crystal{water}{12pt} & %
@@ -98,13 +98,13 @@
 
   \begin{jobchoice}
     \crystal{fire}{12pt} \crystal{water}{12pt} & %
-    \tspec{Multitalented}: Requires Fire level 10 and Water level 13. Choose \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use third level performances of the chosen type even without the required action. \\
+    \tspec{Multitalented}: Requires Fire level 10 and Water level 13. Choose one third level \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use it as if you had chosen it as your \tability{Artistic Niche}. \\
 
     \crystal{earth}{12pt} \crystal{air}{12pt} & %
     \tspec{Encouragement}: Requires Earth and Air level 10 and Water level 12. You gain the \actype[reaction=true] \taction{!Do Over}: Use this \actype[reaction=true] after an ally rolls an attack. Your ally may re-roll the attack. \\
 
     \crystal{fire}{12pt} & %
-    \tspec{Arcane Heart}: Requires Fire level 14. Your MP multiplier becomes 2x if not greater. In addition, you gain one of the following Spell groups: \tspellgroup{Shield}, \tspellgroup{Armor}, \tspellgroup{Regeneration} or \tspellgroup{Divination}. \\
+    \tspec{Arcane Heart}: Requires Fire level 14. Increase your MP bonus multiplier at all levels by 1 if its level 1 value is 1x or less. In addition, you gain one of the following Spell groups: \tspellgroup{Shield}, \tspellgroup{Armor}, \tspellgroup{Regeneration} or \tspellgroup{Divination}. \\
   \end{jobchoice}
 \end{ffminipage}
 
@@ -114,16 +114,12 @@
 
   \begin{jobchoice}
     \crystal{water}{12pt} & %
-    \tspec{Artistic Mastery}: Requires Water level 20. Choose \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use fourth level performances of the chosen type even without the required action. \\
+    \tspec{Artistic Mastery}: Requires Water level 20. Choose one fourth level \tperformance{Dance}, \tperformance{Song} or \tperformance{Mimicry}. You may use it as if you had chosen it as your \tability{Artistic Niche}. \\
 
     \crystal{earth}{12pt} & %
-    \tspec{Powerful Chord}: Requires Earth level 20. Whenever you  \taction{Attack}, you can choose whether it will be physical or magical, regardless of the equipped weapon. In addition, add twice your Earth level to your weapon's damage. \review{When using this attack or permanantly?} \\
+    \tspec{Powerful Chord}: Requires Earth level 20. Whenever you \taction{Attack}, you can choose whether it will be physical or magical, regardless of the equipped weapon. In addition, add twice your Earth level to your weapon's damage for all actions. \\
 
     \crystal{air}{12pt} & %
     \tspec{Dedicated Fans}: Requires Air level 20. When you suffer damage or an attack, you may, as a reaction, force an ally to use a reaction he could use if he had suffered the damage or attack. Spend your initiative die in place of theirs. Furthermore, your allies may use their reactions when you suffer damage or an attack, as if the damage or the attack had affected that ally, spending their own die. In both cases, if the ally's reaction fails, you suffer the attack's effects normally. \\
   \end{jobchoice}
 \end{ffminipage}
-
-
-
-

--- a/core/revised/berserker.tex
+++ b/core/revised/berserker.tex
@@ -1,13 +1,13 @@
 \begin{jobdesc}[name=sjob-berserker]
-    Through offensive maneuvers, a Berserker believes that the best defense is a good offense and try to cause as much damage as quickly as possible. Water is an important Stat to this class. Be a Berserker if you want to increase your ability to cause physical damage as soon as possible; after all, dead enemies don’t fight. \pc
+    A Berserker believes that the best defense is a good offense and try to cause as much damage as quickly as possible through offensive maneuvers. Water is an important Stat to this class. Be a Berserker if you want to increase your ability to cause physical damage as soon as possible; after all, dead enemies don’t fight. \pc
 
-    \textbf{Representatives}: Monk Job (FFV, FFT), Cyan Garamonde (FFVI), Berserker Job (FFV), Viking Job (FFIII) \pc
+   \textbf{Representatives}: Monk Job (FFV, FFT), Cyan Garamonde (FFVI), Berserker Job (FFV), Viking Job (FFIII) \pc
 \end{jobdesc}
 
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Counter Attack}: Core Ability acquired at level 1. After suffering the damage of a \tatk{physical} attack, you can discard any initiative die to perform the \taction{Attack} action against the character who attacked you. \taction{Attack} actions made with Counter Attack have 0 difficulty. \pc
+\noindent\tability{Counter Attack}: Core Ability acquired at level 1. After suffering the damage of a \tatk{physical} attack, you can perform the \taction{Attack} action as an interrupt against the character who attacked you. \taction{Attack} actions made with Counter Attack have 0 difficulty. \pc
 
 \begin{jobchoice}
 \crystal{air}{12pt} \crystal{fire}{12pt} & %
@@ -15,29 +15,29 @@
 \crystal{earth}{12pt} \crystal{water}{12pt} & %
 \tspec{Riposte}: Requires Earth level 6 and Water level 4. After receiving a \tatk{physical} attack, you may use your Counter Attack even if the attack fails for any reason. \\
 \crystal{earth}{12pt} \crystal{air}{12pt} & %
-\tspec{Kharmic Strike}: Requires Earth and Air level 5. During your Counter Attack, you ignore the target’s \tstatus{Flight} status. Increase the difficulty of reactions to your Counter Attack by 30. \\
+\tspec{Kharmic Strike}: Requires Earth and Air level 5. During your Counter Attack, you ignore the target’s positive statuses. Increase the difficulty of reactions to your Counter Attack by 30. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Provoke}: Core Ability acquired at level 19. You gain the Quick \tatk{magical} action \taction{Provoke}. Insult your opponent, causing him to attack you or lose focus. Make a Water vs Fire attack, difficulty 20. If successful, until the end of the next round, if the targeted enemy doesn’t include you as a target in any of his attacks, you may perform the \taction{Attack} action against him as a free action after the enemy’s action. You may add your Air level to your ARM and your Water level to your MARM. \pc
+\noindent\tability{Provoke}: Core Ability acquired at level 19. You gain the Quick \tatk{magical} action \taction{Provoke}. Insult your opponent, causing him to attack you or lose focus. Make a Water vs Fire attack, difficulty 20. If successful, until the end of the next round, every time the targeted enemy target one of your allies and doesn’t target you with his actions, you may perform the \taction{Attack} action against him as a free action after the enemy’s action. You may add your Air level to your ARM and your Water level to your MARM. \pc
 
 \begin{jobchoice}
 \crystal{earth}{12pt} & %
 \tspec{Ignore the Pain}: Requires Earth level 16. Increase your ARM by 50\% against attacks made by enemies under the effect of the \taction{Provoke} action. \\
 \crystal{fire}{12pt} & %
-\tspec{Howl}: Requires Fire level 10. You gain the Ranged Quick \tatk{magical} action \taction{Howl}. Roaring to intimidate your opponents, you make them more vulnerable to magical effects. Perform a Water vs Water attack, difficulty 40. This action causes the \tstatus{Weaken (Mental)} status on a target until the end of the next round. \\
+\tspec{Howl}: Requires Fire level 10. You gain the Ranged Quick \tatk{magical} action \taction{Howl}. Roaring to intimidate your opponents, you make them more vulnerable to magical effects. Perform a Water vs Water attack, difficulty 70, against all enemies. This action causes the \tstatus{Weaken (Mental)} status on to enemies hit until the end of the next round. \\ 
 \crystal{earth}{12pt} \crystal{fire}{12pt} & %
-\tspec{Sovereign Mind}: Requires Earth level 9 and Fire level 7. When performing a Counter Attack or \taction{Hamedo}, instead of the \taction{Attack} action, you may use any of your actions that that can target the opponent, provided the action is not Slow. \\
+\tspec{Sovereign Mind}: Requires Earth level 9 and Fire level 7. When performing a Counter Attack or \taction{Hamedo}, instead of the \taction{Attack} action, you may use any of your actions with zero charge time that that can target the opponent. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Fury}: Core Ability acquired at level 35. While your current HP is 25\% of your max HP or less, you gain the \tstatus{Strengthen (Physical)} status. You lose this status if your current HP is more than 25\% of your max HP for any reason. In addition, you gain the \tspell{Dispel} Spell at level 40. \pc
+\noindent\tability{Fury}: Core Ability acquired at level 35. While your current HP is 25\% of your max HP or less, choose and gain the \tstatus{Strengthen (Physical)} or \tstatus{Strengthen (Magical)} status. You lose this status if your current HP is more than 25\% of your max HP for any reason. In addition, you gain the \tspell{Dispel} Spell at level 40. \pc
 
 \begin{jobchoice}
 \crystal{water}{12pt} & %
-\tspec{Bloodlust}: Requires Water level 12. While your current HP is 25\% of your max HP or less, your allies gain the \tstatus{Strengthen (Physical)} status. Your allies lose this status if your current HP is more than 25\% of your max HP for any reason. \\
+\tspec{Bloodlust}: Requires Water level 12. While your current HP is 25\% of your max HP or less, \tability{Fury}grants its effects to all your allies. Your allies lose the status if your current HP is more than 25\% of your max HP for any reason. \\
 \crystal{air}{12pt} \crystal{water}{12pt} & %
 \tspec{Critical Comeback}: Requires Air level 14 and Water level 12. Whenever you suffer a critical hit, gain an extra initiative die with the value 10. \\
 \end{jobchoice}

--- a/core/revised/blackmage.tex
+++ b/core/revised/blackmage.tex
@@ -3,7 +3,7 @@
 
     \textbf{Representatives}: Black Mage Job (FFI, FFII, FFV, FFX-2, FFXI, FFT, FFTA), Lulu (FFX), Palom of Mysidia (FFIV), Vivi Ornitier (FFIX) \pc
 
-    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=7x,mpa=3x,mpc=4x,armor=Light,weapons=Claws/Gloves \\ Staves \\ Wands]
+    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=7x,mpa=2x,mpb=3x,mpc=4x,armor=Light,weapons=Light Swords/Knives \\ Claws/Gloves \\ Staves \\ Wands]
 \end{jobdesc}
 
 \begin{ffminipage}
@@ -56,7 +56,7 @@
 \crystal{fire}{12pt} \crystal{water}{12pt} & %
 \tspec{Worldly Shock}: Requires Fire level 10 and Water level 7. Your Spells ignore half of targets’ MARM. \\
 \crystal{air}{12pt} \crystal{water}{12pt} & %
-\tspec{Careful Casting}: Requires Air level 5 and Water level 8. You may, as you cast a Spell, make it a Slow (3) action. Doing so will reduce by 30 its difficulty, to a minimum of zero. All difficulties listed in the Spell are reduced by this effect. \\
+\tspec{Careful Casting}: Requires Air level 5 and Water level 8. You may, as you cast a Spell, increase its charge time by 3. Doing so will reduce by 30 its difficulty, to a minimum of zero. All difficulties listed in the Spell are reduced by this effect. \\
 \end{jobchoice}
 \end{ffminipage}
 

--- a/core/revised/defender.tex
+++ b/core/revised/defender.tex
@@ -1,0 +1,55 @@
+\begin{jobdesc}[name=sjob-defender]
+    With cover and protective maneuvers, a Defender seeks to protect its allies against attacks, often placing himself in danger. Its main Stat is Earth. Be a Defender if you want to protect your allies, shielding them from damage or negative status effects. \pc
+
+    \textbf{Representatives}: Cecil Harvey (FFIV), Paladin Job (FFXI, FFTA) \pc
+\end{jobdesc}
+
+\begin{ffminipage}
+{\centering \textbf{Abilities}\par }
+
+\noindent\tability{Cover}: Core Ability acquired at level 1. You gain the \actype[reaction=true] \taction{Cover}. Use it when an ally is hit by a physical attack. You suffer the effects of the attack, rather than the ally. As a free action, you can use another reaction against the attack, if able.  \pc
+
+\begin{jobchoice}
+\crystal{earth}{12pt} & %
+\tspec{Sentinel}: Requires Earth level 5. As a free action, when an ally with current HP equal to or less than 25\% or his max HP suffers a physical attack, you may suffer the attack instead of the original target. \\
+\crystal{water}{12pt} & %
+\tspec{Arcane Defense}: Requires Water level 4. You may use \taction{Cover} to react when an ally suffers a magical attack or Spell. \\
+\crystal{earth}{12pt} \crystal{air}{12pt} & %
+\tspec{Armor Training}: Requires Earth and Air level 3. Use the greater between Earth and Air Values to calculate your HP. Also, increase your HP bonus multiplier by one at all levels, if its level 1 value is 4x or lower, and gain one armor type as a equipment choice. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+\noindent\tability{Share the Pain}: Core Ability acquired at level 19. You gain the \actype[reaction=true] \taction{Shared Pain}. Use when hit by a Melee physical attack. Do an Earth vs Earth attack, difficulty 70. If successful, after reducing the damage by your Armor, split the damage evenly between you and the opponent who attacked you, bypassing the opponent's Armor. You may add your Air level to your ARM and your Fire level to your MARM. \pc
+
+\begin{jobchoice}
+\crystal{fire}{12pt} \crystal{water}{12pt} & %
+\tspec{Healing Wind}: Requires Fire and Water level 5. Increase your MP bonus multiplier by one. In addition, you gain the \tspellgroup{Healing} Spell group. Your \tspellgroup{Healing}-group Spells cost double MP and target you and all your allies rather than a single target (using single-target healing value for you and each ally). \\
+\crystal{earth}{12pt} \crystal{air}{12pt} \crystal{fire}{12pt} & %
+\tspec{Defensive Mastery}: Requires Earth, Air and Fire level 8. Reduce by 20 the difficulty of any reaction you perform. \\
+\crystal{earth}{12pt}& %
+\tspec{Noble Sacrifice}: Requires Earth level 9. As a free action, when an ally suffers an attack that inflicts a negative status effect you don't have, you may suffer its effects instead. When using \tspec{Noble Sacrifice}, ignore your immunities. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+\noindent\tability{Astra}: Core Ability acquired at level 35. You gain the \tspell{Astra} Spell. \pc
+
+\begin{jobchoice}
+\crystal{earth}{12pt} \crystal{fire}{12pt} & %
+\tspec{Astraga}: Requires Earth and Fire level 13. You gain the Astraga Spell. \\
+\crystal{air}{12pt} \crystal{water}{12pt} & %
+\tspec{Perseu's Mirror}: Requires Air and Water level 13. Whenever a status effect caused by an opponent is blocked by the \tspell{Astra} Spell, you may immediately repeat the blocked attack as an interrupt using that opponent as target. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+\noindent\tability{Immortal Body}: Core Ability acquired at level 50. At the start of each combat, you gain the \tstatus{Reraise} status. \pc
+
+\begin{jobchoice}
+\crystal{earth}{12pt} & %
+\tspec{Immortal Soul}: Requires Water level 18. You gain the Great Gospel Spell. \\
+\crystal{fire}{12pt} & %
+\tspec{Immortal Technique}: Requires Air level 18. Choose a reaction from of any Job. You gain that reaction. \\
+\end{jobchoice}
+\end{ffminipage}

--- a/core/revised/dervish.tex
+++ b/core/revised/dervish.tex
@@ -7,7 +7,7 @@
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Ambidexterity}: Core Ability acquired at level 1. You may equip Twin Weapons. \pc
+\noindent\tability{Ambidexterity}: Core Ability acquired at level 1. You may equip Twin Blades. \pc
 
 \begin{jobchoice}
 \crystal{air}{12pt} & %
@@ -24,7 +24,7 @@
 
 \begin{jobchoice}
 \crystal{earth}{12pt} \crystal{water}{12pt} & %
-\tspec{Blade Barrier}: Requires Earth and Water level 6. The best defense is a good offense. Add your Earth level to your ARM and your Water level to your MARM. \\
+\tspec{Zen Focus}: Requires Earth and Water level 7. At the beginning of each round, you may roll one fewer initiative dice to gain one extra die in a phase you have no initiative dice (you choose which phase after all enemies have rolled initiative). \\
 \crystal{air}{12pt} \crystal{fire}{12pt} & %
 \tspec{Danger Zone}: Requires Air and Fire level 6. At the beginning of each round, you may spend HP equal to 25\% of your max HP to receive the \tstatus{Haste} status during this round. \\
 \crystal{fire}{12pt} \crystal{water}{12pt} & %
@@ -37,14 +37,14 @@
 
 \begin{jobchoice}
 \crystal{air}{12pt} & %
-\tspec{Deep Cut}: Requires Air level 16. When you attain a critical hit with an action that deals damage, ignore the target’s ARM and MARM. \\
-\crystal{earth}{12pt} \crystal{air}{12pt} \crystal{fire}{12pt} \crystal{water}{12pt} & %
-\tspec{Zen Focus}: Requires Earth, Air, Fire and Water level 8. At the beginning of each round, you may choose one of your initiative die’s value instead of rolling it. \\
+\tspec{Deep Cut}: Requires Air level 15. When you attain a critical hit with an action that deals damage, ignore the target’s ARM and MARM. \\
+\crystal{water}{12pt} & %
+\tspec{Lethal Precision}: Requires Water level 16. If you discard an initiative dice after rolling an attack that may not have critical hits, you deal double damage in case of a critical hit. This ability may not be used with Spells. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Fierce Assault}: Core Ability acquired at level 50. If you can act more than once on the same phase, you can perform these actions together. If you do and deal damage, you may add all damage dealt before reducing it by the target’s ARM or MARM. Regardless of how many attacks you do, reduce the ARM or MARM only once. \pc
+\noindent\tability{Fierce Assault}: Core Ability acquired at level 50. After you deal physical damage to a target, your subsequent physical attacks against that target in this phase ignore Armor. After you deal magical damage to a target, your subsequent magical attacks against that target in this phase ignore Magic Armor. \pc
 
 \begin{jobchoice}
 \crystal{earth}{12pt} & %

--- a/core/revised/druid.tex
+++ b/core/revised/druid.tex
@@ -13,12 +13,21 @@
 
 \begin{jobchoice}[header=false]
 \crystal{level}{12pt} & %
-\textit{Primal Arcana}: Requires level 1. Increase your MP bonus multiplier by 1. You may equip light armor. Also, you gain one of the following Spell groups: \tspellgroup{Healing}, \tspellgroup{Fire}, \tspellgroup{Ice}, \tspellgroup{Lightning}, \tspellgroup{Poison}, or \tspellgroup{Slow}. \\
+\textit{Primal Arcana}: Requires level 1. Increase your MP bonus multiplier at all levels by 1. You may equip light armor. Also, you gain one of the following Spell groups: \tspellgroup{Healing}, \tspellgroup{Fire}, \tspellgroup{Ice}, \tspellgroup{Lightning}, \tspellgroup{Poison}, or \tspellgroup{Slow}. \\
 \crystal{level}{12pt} & %
-\textit{Nature Warrior}: Requires level 1. Increase your HP bonus multiplier by 1. You may equip \tequip{heavy armor} and two of the following weapons: \tequip{Heavy Weapons}, \tequip{Bows}, \tequip{Light Swords / Knives}, \tequip{Heavy Weapons \& Shield}, \tequip{Katana}, \tequip{Polearms} or \tequip{Staves}. \\
+\textit{Nature Warrior}: Requires level 1. Increase your HP bonus multiplier at all levels by 1. You may equip \tequip{heavy armor} and two of the following weapons: \tequip{Heavy Weapons}, \tequip{Bows}, \tequip{Light Swords / Knives}, \tequip{Weapons \& Shield}, \tequip{Katana}, \tequip{Polearms} or \tequip{Staves}. \\
 \crystal{level}{12pt} & %
-\textit{Primal Music}: Requires level 1. Increase your HP bonus to 4x your level. Also, you may equip the \tequip{Instruments} weapon type. \\
+\textit{Primal Music}: Requires level 1. Increase your HP bonus and MP bonus multipliers at all levels by 1 each. Also, you may equip the \tequip{Instruments} weapon type. \\
 \end{jobchoice}
+
+\begin{jobchoice}
+    \crystal{air}{12pt} & %
+    \textit{Cursing}: Requires Air level 3. You gain the \tspell{Curse} Spell. \\
+    \crystal{water}{12pt} & %
+    \textit{Nature Lore}: Requires Water level 3. You gain the \actype[ranged=true, magical=true] \taction{Lore}. Using it, you study the opponents to discover its magical abilities. Perform a Water vs Water attack, difficulty 0, to discover the target’s maximum and current HP and MP, and all Spells, if any, it can cast. \\
+    \crystal{earth}{12pt} \crystal{fire}{12pt} & %
+    \textit{Quick Casting}: Requires Earth and Fire level 5. Whenever you spend MP to use a Slow action, you may reduce the MP cost or the charge time by 25\%. \\
+    \end{jobchoice}    
 \end{ffminipage}
 
 \begin{ffminipage}
@@ -27,12 +36,12 @@
 \begin{jobchoice}[header=false]
 \crystal{level}{12pt} & \textit{Blue Mage}: You may learn Blue Magic Spells, but you can only cast Initiate Spells. Learn two Blue Magic Initiate Spells at character creation. Also, whenever you suffer the effects of a Blue Magic Spell and are not reduced to 0 HP, you permanently learn the Spell. The list and description of the \nameref{sec:magic-blue} Spells starts at page~\pageref{sec:magic-blue}. \\
 \crystal{level}{12pt} & \textit{Geomancer}: You earn the Ranged Slow (2) magical action \taction{Geomancy}. The geomancer has the power to use the terrain to his advantage, invoking magical effects. Their powers vary accordingly to the terrain where the battle takes place, be it \nameref{subsec:geo-plains}, \nameref{subsec:geo-forest}, \nameref{subsec:geo-mountain}, \nameref{subsec:geo-snow}, \nameref{subsec:geo-sea}, \nameref{subsec:geo-swamp}, \nameref{subsec:geo-urban}, \nameref{subsec:geo-underground}, \nameref{subsec:geo-lava}, \nameref{subsec:geo-desert}, or \nameref{subsec:geo-cosmic}. The rules for these effects and their descriptions are in the \nameref{sec:magic-geomancy} section, starting at page~\pageref{sec:magic-geomancy}. \\
-\crystal{level}{12pt} & \textit{Summoner}: You gain the Quick \tatk{magical} action \taction{Tame}. To use it, make a Water vs Fire attack, difficulty 40. If successful, you deal non-elemental damage equal to your character level. If the opponent is reduced to 0 HP by this attack, you capture the enemy’s soul, and can release it later with an action to have the captured enemy perform his most powerful attack against targets of your choice. \taction{Tame} may also be used as a reaction when an enemy drops to 0 HP. In this case, the enemy's soul is captured if it hits, regardless of damage. Use the Stats of captured enemy to determine the effects of this action. While you own a captured soul, you may not use the \taction{Tame} action. \\
+\crystal{level}{12pt} & \textit{Summoner}: You gain the Quick \tatk{magical} action \taction{Tame}. To use it, make a Water vs Fire attack, difficulty 40. If successful, you deal \telem{non}-elemental damage equal to your character level. If the opponent is reduced to 0 HP by this attack, you capture the enemy’s soul, and can release it later with an action to have the captured enemy perform his most powerful attack against targets of your choice. \taction{Tame} may also be used as a reaction when an enemy drops to 0 HP. In this case, the enemy's soul is captured if it hits, regardless of damage. Use the Stats of captured enemy to determine the effects of this action. While you own a captured soul, you may not use the \taction{Tame} action. \\
 \end{jobchoice}
 
 \begin{jobchoice}
 \crystal{earth}{12pt} \crystal{air}{12pt} & %
-\textit{Martial Channeling}: Requires Earth and Air level 4. Whenever you use a magical action (but not Spells), you may substitute the attack roll for a weapon attack, maintaining the same difficulty. You are successful in your action if you succeed with the weapon attack. If you do succeed, and the action deals damage, you deal weapon damage instead of the action’s damage. Other than attack roll and damage, this Specialty don't change anything else in the action. \\
+\textit{Martial Channeling}: Requires Earth and Air level 4. Whenever you use a magical action (not Spells), you may substitute the attack roll for a weapon attack, maintaining the same difficulty. You are successful in your action if you succeed with the weapon attack. If you do succeed, and the action deals damage, you deal weapon damage instead of the action’s damage. Other than attack roll and damage, this Specialty don't change anything else in the action. Martial Channeling may not increase the damage of multi-attack actions like \textbf{Branch Spear} and \taction{Kuuton}.\\
 \crystal{fire}{12pt} & %
 \textit{Light Steps}: Requires Fire level 6. You gain the \tspellgroup{Flight} Spell group. \\
 \crystal{water}{12pt} & %
@@ -91,7 +100,8 @@ automatically learning the spell if the roll is equal to or lower than the Blue 
 
 \begin{jobchoice}[header=false]
 \crystal{level}{12pt} & %
-\textit{Blue Mage}: You learn Blue Magic Spells after suffering them even if they are reduced to 0 HP because of its effect and increase your MP bonus by 1 times their level. Also, you may can now cast Master and Ancient Spells. \\
+\textit{Blue Mage}: You learn Blue Magic Spells after suffering them even if they are reduced to 0 HP because of its effect. Also, you may can now cast \nameref{subsec:blue-M
+master} and \nameref{subsec:blue-ancient} Spells. \\
 \crystal{level}{12pt} & %
 \textit{Geomancer}: One status effect is permanently applied to you. Which status is gained is based on your lowest Stat value when he reaches level 30. You may choose between status in case of a tie: \textbf{Earth} --- Puncture Resist; \textbf{Air} --- Float; \textbf{Fire} --- Premonition; \textbf{Water} --- Blink. \\ % chktex 8 it doesn't like any dashes
 \crystal{level}{12pt} & %
@@ -100,7 +110,7 @@ automatically learning the spell if the roll is equal to or lower than the Blue 
 
 \begin{jobchoice}
 \crystal{fire}{12pt} \crystal{water}{12pt} & %
-\textit{Quagmire}: Requires Fire level 8 and Water level 10. You gain the Slow (4) magical action \textbf{!Quagmire}. Using it, you realize a (Water or Fire) vs Water attack against a target, difficulty 40. This attack automatically fails against targets under the effect of \textbf{Float} or Flight status effects. If successful, you deal 17x Water level Water-elemental damage and inflict the \textbf{Slow} status over the next two rounds. At 40th level or greater, you may spend 60 MP to use this action against a group, rather than a single target. \\
+\textit{Quagmire}: Requires Fire level 8 and Water level 10. You gain the Slow (4) magical action \textbf{!Quagmire}. Using it, you realize a (Water or Fire) vs Water attack against a target, difficulty 40. This attack automatically fails against targets under the effect of \textbf{Float} or Flight status effects. If successful, you deal 17x Wat0er level Water-elemental damage and inflict the \textbf{Slow} status over the next two rounds. At 40th level or greater, you may spend 60 MP to use this action against a group, rather than a single target. \\
 \crystal{water}{12pt} \crystal{air}{12pt} & %
 \textit{Truce}: Requires Water level 12 and Air level 8. You gain the Ranged Quick magical action \textbf{!Truce}. Speaking the monsters’ language, you try to make them pause for a moment. Do a Water vs Fire, difficulty 40, attack against all enemies. The enemies hit cannot target your party with actions for the next 3 phases. Remove this effect if the target suffers damage. This has no effect on phase 10. Treat this as a \textbf{Mental}-type status effect. \\
 \crystal{earth}{12pt} \crystal{fire}{12pt} & %

--- a/core/revised/druid.tex
+++ b/core/revised/druid.tex
@@ -100,8 +100,7 @@ automatically learning the spell if the roll is equal to or lower than the Blue 
 
 \begin{jobchoice}[header=false]
 \crystal{level}{12pt} & %
-\textit{Blue Mage}: You learn Blue Magic Spells after suffering them even if they are reduced to 0 HP because of its effect. Also, you may can now cast \nameref{subsec:blue-M
-master} and \nameref{subsec:blue-ancient} Spells. \\
+\textit{Blue Mage}: You learn Blue Magic Spells after suffering them even if they are reduced to 0 HP because of its effect. Also, you may can now cast \nameref{subsec:blue-master} and \nameref{subsec:blue-ancient} Spells. \\
 \crystal{level}{12pt} & %
 \textit{Geomancer}: One status effect is permanently applied to you. Which status is gained is based on your lowest Stat value when he reaches level 30. You may choose between status in case of a tie: \textbf{Earth} --- Puncture Resist; \textbf{Air} --- Float; \textbf{Fire} --- Premonition; \textbf{Water} --- Blink. \\ % chktex 8 it doesn't like any dashes
 \crystal{level}{12pt} & %

--- a/core/revised/engine.tex
+++ b/core/revised/engine.tex
@@ -258,7 +258,7 @@ Later in his adventures, JBMog, now a \ordinalnum{30} level character, was in a 
 \end{multimog}
 
 \begin{multiboco}
-Optional Rule: \textbf{Scaling down the Numbers}\label{subsec:scaling}
+Optional Rule: \textbf{Scaling down the Numbers}\label{optrule:scaling}
 
 The FFRPG 4th edition kept the d100 mechanic from earlier iterations of the Returner’s games. However, the dice used increases the burden of an already-crunchy game. This optional rule revamps the whole game engine with lower numbers, and generally speeds up play, easing the math burden.
 

--- a/core/revised/engine.tex
+++ b/core/revised/engine.tex
@@ -94,44 +94,47 @@ When two players cannot agree on something, just have the two spend any number o
 Combat is the raison d’etre of many rules through this book. All rules regarding Jobs, Spells and Equipment are only tools to be used during tactical combat. The rules described below turn combative moments in a simulation that uses all the concepts discussed so far to present tactical challenges to the group. Each fight consists of rounds that follow until one side has fled, surrendered or been defeated.
 
 \subsection{Initiative}\label{subsec:init}
-At the beginning of each round, each character involved in the fight will roll 3d10 and record the values. The die roll total is his initiative and the result of each dice means the character's actions. After the initiative roll, the round will continue for 10 phases, starting from phase 1 and ending in phase 10. The phases happen sequentially, in ascending order. In phase 1, all characters who had at least one result ``1'' in one of the initiative dice may take an action.
+At the beginning of each round, each character involved in the fight will roll 3d10 and record the values. The die roll total is his initiative and the result of each dice means the character's actions. After the initiative roll, the round will continue for 10 phases, starting from phase 1 and ending in phase 10. The phases happen sequentially, in ascending order. In phase 1, all characters who had at least one result ``1'' in one of the initiative dice may take one action for each die that shows ``1''.
 
 If more than one character acts the same phase, the one with the highest total initiative acts first. If the characters have the same total initiative, the one with the greater Air Stat will act first. After acting, the character discards the current phase initiative die, reducing his initiative total. When there are no more characters able to act in phase 1, the round will move to phase 2 and so on. After phase 10 ends, the round ends and a new round begins.
+
+\begin{boco}
+    Optional Rule: \textbf{Team Initiative}
+    Should you want a simpler way to track initiative, run each phase by having the all player characters do their actions first, then all enemies. Both the player characters and the enemies take actions at any desired order inside their team's turn. After all enemies have taken their action, move to the next phase. 
+    \end{boco}
+    
 
 \subsection{Action Types}\label{subsec:actions}
 \subsubsection{Standard Action}
 A standard action takes place along the lines described above. The player uses an initiative die with value equal to the current phase to act.
 
 \subsubsection{Interrupt Action}
-This action occurs when the character does not have any initiative dice representing the current phase. The player may discard any TWO initiative die to act.
+This action occurs when the character can't or does not want to spend a initiative dice representing the current phase. Any character may perform any action or reaction at any phase by spending \textbf{two} initiative die of any value. Some abilities allow the character to perform actions "as an interrupt" by spending one initiative dice of any value in specific situations.
 
-\subsubsection{Improved Interrupt Action}
-This action behaves as the Interrupt action except that the character must only spend one die and it may only be used as indicated in an ability granting it.
-
-\subsubsection{Action}
-In this case, the character chooses not to act at this phase even having an initiative die with the correct value. He may then postpone the action to a later phase. The delayed die’s result is counted for the initiative total at its original value. A character may not delay more than one action at the same time.
+\subsubsection{Delayed Action}
+In this case, the character chooses not to act at this phase even having an initiative die with the correct value. He may then postpone the action to a later phase. The delayed dice’s result is counted for the initiative total at its original value. A character may not delay more than one action at the same time.
 
 \subsubsection{Free Action}
 The free action occurs without the character spending an initiative dice. It occurs at specific times determined by the rule that creates it. An example of free action is talking.
 
 \subsection{Speeds}\label{subsec:speeds}
 \subsubsection{Quick Action}
-A Quick action occurs when the character acts. The character discards the initiative dice and its effects are immediate.
+A Quick action occurs when the character acts. The character discards the initiative dice and its effects are immediate. A action with charge time of zero is a quick action.
 
 \subsubsection{Slow Action}
-A Slow (X) action implies that the character must prepare it before performing. He declares the action as usual, and then spends (X) phases preparing their action. Only after this time has elapsed, the action’s effects will happen. During this preparation time, he may not react or do any other actions, but may delay their actions. If he needs to delay more than one action, as he may not delay more than one action, the extra actions are lost.
+A Slow (X) action implies that the character must charge before performing. He declares the action as usual, and then spends (X) phases charging their action. Only after this time has elapsed, the action’s effects will happen. During this charging time, he may not react or do any other actions, but may delay their actions. If he needs to delay more than one action, as he may not delay more than one action, the extra actions are lost. All actions with a charge time of 1 or greater are Slow actions. Some effects may increase or decrease the charge time of your actions, changing the number of phases you need to charge the Slow action.
 
-In addition, if the Slow action require you to prepare your action beyond phase 10, you lose all initiative die this round and, in the next round, roll one fewer initiative dice. At the phase when you finish the preparation, the action’s effects happen as usual. For example, a character initiates a Slow (7) action in phase 6. In the next round, he rolls one fewer initiative dice and in Phase 3, the action’s effects happen.
+In addition, if the Slow action require you to prepare your action beyond phase 10, you lose all non-delayed initiative die this round and, in the next round, roll one fewer initiative dice. At the phase when you finish the preparation, the action’s effects happen as usual. For example, a character initiates a Slow (7) action in phase 6. In the next round, he rolls one fewer initiative dice and in Phase 3, the action’s effects happen.
 
 \subsubsection{Reaction}
-Reactions occur when the character uses specific abilities. They interrupt other actions and must be resolved before the first action’s effects are applied. In response, the character can spend an initiative dice with the current phase’s value, use a delayed action or even perform an interruption. Some reactions are free actions. A character may wait to see if an action is successful or not before declaring his reaction.
+Reactions occur when the character uses specific abilities. They interrupt other actions and must be resolved before the first action’s effects are applied. To use a reaction, the character can spend an initiative dice with the current phase’s value, use a delayed action or even perform an interruption. Some reactions are free actions. A character may wait to see if an action is successful or not before declaring his reaction.
 
 \subsection{Attacks and Rolls in Combat}\label{subsec:attacks}
 All rolls in combat (attack rolls, reactions, Spells, etc.) have the following characteristics: One Offensive Stat, one Defensive Stat and a difficulty. For example, the \taction{Attack} action using a Bow is an Air (Offensive stat) vs Air (Defensive stat) attack, difficulty 40. The roll is as follows: The player will roll 1d100 and add his Offensive Stat’s value. He will be successful if the result is higher than difficulty + the target’s Defensive Stat’s value. If target choose to not resist the action, it is always successful, unless the action says otherwise.
 
 If the attack is against a group (be it ally’s or enemy’s), the player must perform only one roll. After adding the d100 roll to Offensive Stat’s value, it should compare it separately with the sum of difficulty + Defensive Stat’s value of each target and may be successful against only part of the opponents.
 
-If the attack deals damage or recover HP or MP, the d100’s unit digit will be added to the damage dealt or value healed, unless the attack says otherwise. Finally, if a character re-rolls an attack, either because he can re-roll one of his attacks, or because the target can force his opponent to re-roll his attacks, this character can wait until knowing whether the attack would be successful or not before choosing to re-roll or not. If a character re-rolls an attack, always use the second roll, even if worse than the first.
+If the attack deals damage or recover HP or MP, the d100’s unit digit will be added to the damage dealt or value healed, unless the attack says otherwise. Finally, if a character re-rolls an attack, either because he can re-roll one of his attacks, or because the target can force his opponent to re-roll his attacks, the character can look at the results and choose the best (or be forced to choose the worst).
 
 Each attack, except Spells, may be Ranged or Melee. All Ranged attacks are noted as such; every non-Ranged attack is Melee. Flying enemies may not be hit by Melee attacks, unless the attacker is also Flying. Spells and Reactions aren't neither Ranged nor Melee and may target Flying enemies normally.
 
@@ -139,7 +142,7 @@ Each attack, except Spells, may be Ranged or Melee. All Ranged attacks are noted
 All characters can perform the following actions, regardless of equipment, Job or Abilities.
 
 \subsubsection{\taction{Attack}}
-Quick action. If the character is unarmed, perform an Earth vs Earth attack, difficulty 70. The damage is physical, Crush-elemental, equal to Earth level. If it is equipped with a weapon, use the weapon’s Offensive and Defensive Stats, difficulty 40, and deal weapon damage. The Wealth and Items section, below, has more details about the weapons between pages 94 to 107. This action may score critical hits, dealing twice damage.
+Quick action. If the character is unarmed, perform an Earth vs Earth attack, difficulty 70. The damage is physical, \telem{Crush}-elemental, equal to Earth level. If it is equipped with a weapon, use the weapon’s Offensive and Defensive Stats, difficulty 40, and deal weapon damage. The Wealth and Items section, below, has more details about the weapons between pages 94 to 107. This action may score critical hits, dealing twice damage.
 
 \subsubsection{\taction{Dodge}}
 Reaction. Use when suffering a physical attack. Roll Air vs Earth, difficulty 70. If successful, you don’t suffer the attack’s effects.
@@ -201,7 +204,7 @@ First, do steps 1 to 3 before you even land a blow. Having your damage pre-calcu
 
 Second, remember that 50\% is one half, and 25\% is half of a half. 10\% is the number, ignoring the unit digit. Round down your calculations to speed them. To find a quarter of 138, for example, halve it first (69) then halve it again (34). 150\% is one plus half; 125\% is one plus a quarter; and 75\% is one minus a quarter.
 
-Lastly, try to cancel opposite modifiers, even if the numbers aren't exactly equal. A \taction{Mighty Blow} or Critical Hit against an enemy with Protect deals normal weapon damage; If you use \taction{Kick} on a Vulnerable enemy, it also deals normal weapon damage; and so on. Keep in mind that speed trumps math accuracy.
+Lastly, try to cancel opposite modifiers, even if the numbers aren't exactly equal. A \taction{Mighty Blow} or Critical Hit against an enemy with Protect deals normal weapon damage; If you use \taction{Guardbreak} on a Vulnerable enemy, it also deals normal weapon damage; and so on. Keep in mind that speed trumps math accuracy.
 \end{boco}
 
 \subsection{Healing}\label{subsec:heal}
@@ -235,18 +238,18 @@ Lastly, there are no specific Combat rules. To resolve combats, use Challenges a
 \begin{multimog}
 Later in his adventures, JBMog, now a \ordinalnum{30} level character, was in a dungeon with his friends Rob, a \ordinalnum{28} level Warrior/Rune Knight and Nyarly, a \ordinalnum{31} level Adept/Wizard. After an unfortunate failed Challenge roll, they fell into a trap, activating an iron Golem guardian. \\
 \textbf{GM}: \enquote{Start of Round 1. The creature rolls 1, 3 and 6 as initiative. Roll your initiative!} \\
-\textbf{JB}: \enquote{5, 7 and 9. I use my Preemptive Strike to change the 9 to 1. My initiatives are 1, 5 and 7!} \\
+\textbf{JB}: \enquote{5, 6 and 9. I use my Preemptive Strike to change the 9 to 1. My initiatives are 1, 5 and 6!} \\
 \textbf{Rob}: \enquote{3, 3, and 8. And Nyarly rolled 4, 5, and 10} \\
 \textbf{GM}: \enquote{Phase 1. You're first JB, then Golem acts.} \\
 \textbf{JB}: \enquote{I'll strike the golem with my lance. I rolled a 61, plus my Air is 148 total. It hits?} \\
 \textbf{GM}: \enquote{You try to attack him with your polearm, but the heavy armor of the golem deflects it (The attack targets Earth plus dif 40. His value is 112, so he needed to overcome 152 to hit). He ignores your attacks while he prepares his own. He starts charging a Slow axe attack against Nyarly. We begin Phase 2, and his attack is finished. I roll a 34 (plus his 112 Earth totals 145) for a total 114 damage (110 damage plus 34's singles digit).} \\
-\textbf{Nyarly}: \enquote{Yikes! I will use an interrupt action and react to use \taction{Will Shield}. I spend the 4 and 10 dice. I rolled a 69, for a total of 149. I made it? (The GM nods, as \taction{Will Shield} have a 10 difficulty and the Golem's Earth value is only 112.) Nyarly creates a magical shield that blocks the blow and spends 35 MP (114 minus her 44 Armor is 70 damage. She spends half that MP).} \\
+\textbf{Nyarly}: \enquote{Yikes! I will use an interrupt action and react to use \taction{Will Shield}. I spend the 4 and 10 dice. I rolled a 69, for a total of 149. I made it? (The GM nods, as \taction{Will Shield} have a 10 difficulty and the Golem's Earth value is only 112.) Nyarly creates a magical shield that blocks the blow and spends 14 MP (10\% of his 143 MP).} \\
 \textbf{Rob}: \enquote{Seems no one got actions in Phase 2, so I'm acting at phase 3. Seems that his weak spot is Air, so my first action is to draw my Meteo Knuckle. My second action (Rob can act before the golem since his initiative total is 11 and the Golem's is 9) is to use \taction{Item} to stash my Old Axe and equip the gloves.} \\
 \textbf{GM}: \enquote{The Golem starts to leak out a strange gas. It attacks all characters, rusting your equipment! Who got Water lower than 43 is hit with the Weaken (Armor) status until the end of the next round.} (The GM rolled a 31. 31 plus the Golem's Fire value is 113, and the attack targeted the group and had diff 70) \\
-\textbf{JB}: \enquote{I think the only one hit was Rob (Rob nods). My turn now, right? (Nyarly's initiative total is 5, while JB's is 12) I'll use \taction{Advice} on Rob. I want him to crit with that knuckle!} \\
-\textbf{Nyarly}: \enquote{So, now it is my turn. I'll spend 61 HP to unleash a \taction{Fury Brand}. Rolled 90 for a total of 181 vs Water+40. If it hits, that's 131 Fire damage and Berserk.} \\
-\textbf{GM}: \enquote{Yeah, that hits. Your staff burns with your magical fire when you sacrifice your lifeforce to summon a cleansing flame. Your strike hits true, dealing 101 damage (that's 121 minus the 30 MARM), but the creature seems to be immune to your mental effect. In the golem's turn at phase 6, he delays his action.} \\
-\textbf{JB}: \enquote{I'll keep attacking at phase 7. Let me roll for Geomancy! Hm\ldots 75? What’s the Major effect for Underground? Ah, Cave In. I'll spend the 35 MP to increase the damage. (JB rolls a 51 and hits) That's 101 damage (100 damage plus 51's singles digit)! Take that!} \\
+\textbf{JB}: \enquote{I think the only one hit was Rob (Rob nods). My turn now, right? (Nyarly's initiative total is 5, while JB's is 11) I'll use \taction{Advice} on Rob. I want him to crit with that knuckle!} \\
+\textbf{Nyarly}: \enquote{So, now it is my turn. I'll spend 60 HP to unleash a \taction{Fury Brand}. Rolled 90 for a total of 181 vs Water+40. If it hits, that's 131 Fire damage and Berserk.} \\
+\textbf{GM}: \enquote{Yeah, that hits. Your staff burns with your magical fire when you sacrifice your lifeforce to summon a cleansing flame. Your strike hits true, dealing 101 damage (that's 131 minus the 30 MARM), but the creature seems to be immune to your mental effect. In the golem's turn at phase 6, he delays his action.} \\
+\textbf{JB}: \enquote{I'll charge Geomancy. No actions until phase 8? Ok. Let me roll for Geomancy! Hm\ldots 75? What’s the Major effect for Underground? Ah, Cave In. I'll spend the 35 MP to increase the damage. (JB rolls a 51 and hits) That's 101 damage (100 damage plus 51's singles digit)! Take that!} \\
 \textbf{GM}: \enquote{Rocks fall, and the Golem receives 71 damage from the cave in, but he's still rocking!} \\
 \textbf{Rob}: \enquote{Phase 8? At last! I'll attack him\ldots Oh, only 11\ldots I miss\ldots No, wait, I crit due to JB! Thanks! I'll do-} \\
 \textbf{GM}: \enquote{Actually the Golem reacts with his delayed action. He rolls a 17 to block and/ldots (checks Rob's Earth value of 111) fails. Your critical does only 19 damage due to the golem's heavy armor but roll for Meteorite!} \\
@@ -255,7 +258,7 @@ Later in his adventures, JBMog, now a \ordinalnum{30} level character, was in a 
 \end{multimog}
 
 \begin{multiboco}
-Optional Rule: \textbf{Scaling down the Numbers}
+Optional Rule: \textbf{Scaling down the Numbers}\label{subsec:scaling}
 
 The FFRPG 4th edition kept the d100 mechanic from earlier iterations of the Returner’s games. However, the dice used increases the burden of an already-crunchy game. This optional rule revamps the whole game engine with lower numbers, and generally speeds up play, easing the math burden.
 

--- a/core/revised/fencer.tex
+++ b/core/revised/fencer.tex
@@ -56,6 +56,6 @@
 \tspec{Water Dancer}: Requires Water level 18. Melee actions cannot target you unless you acted in the last 3 phases. \\
 \crystal{fire}{12pt} & %
 \tspec{Fire Dancer}: Requires Air level 18. Reduce the difficulty of all actions and reactions you perform on the second or third phase by 5; on the fourth or fifth phase by 10; on the sixth or seventh phase by 15; on the eighth or ninth phase by 20 and on the tenth phase by 25. 
-\textit{(Using the scaling down optional rule, page~\pageref{subsec:scaling}, reduce the difficulty of actions and reactions on fourth, fifth and sixth phase by 1, on seventh, eighth or ninth by 2 and on tenth by 3)} \\
+\textit{(Using the scaling down optional rule, page~\pageref{optrule:scaling}, reduce the difficulty of actions and reactions on fourth, fifth and sixth phase by 1, on seventh, eighth or ninth by 2 and on tenth by 3)} \\
 \end{jobchoice}
 \end{ffminipage}

--- a/core/revised/fencer.tex
+++ b/core/revised/fencer.tex
@@ -1,21 +1,21 @@
 \begin{jobdesc}[name=sjob-fencer]
-    Offensive Job focused on fighting with two weapons to strike fast and often. Its main Stat is Air. Be a Dervish if you want to increase the amount and speed of your actions and be a great physical damage dealer. \pc
+    Defensive job that believes that the best way of not dying is being out of the way of attacks. Its main Stat is Air. Be a Fencer if you want to dodge the attacks of your opponents, especially their missiles, and manipulate the flow of actions in battle, thus increasing your and your allies’ survival. \pc
 
-    \textbf{Representatives}: Edward Geraldine “Edge” Eblan (FFIV), Clyde “Shadow” Arrowny (FFVI), Ninja Job (FFI, FFIII, FFV, FFXI, FFT, FFTA) \pc
+    \textbf{Representatives}: Fencer Job (FFTA) \pc
 \end{jobdesc}
 
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Ambidexterity}: Core Ability acquired at level 1. You may equip Twin Weapons. \pc
+\noindent\tability{Block Projectiles}: Core Ability acquired at level 1. You may equip medium armor and gain the reaction\actype[reaction=true] \taction{Arrow Guard}. When you are hit by a Ranged attack, make an Air vs Air attack, difficulty 30. If successful, you don’t suffer the attack’s effects. This does not affect Spells. \pc
 
 \begin{jobchoice}
+\crystal{fire}{12pt} & %
+\tspec{Lightning Strike}: Requires Fire level 3. Opponents cannot use interrupt actions to react to your attacks. In addition, choose one: \tequip{Bows} or \tequip{Light Sword / Knives}. You may equip the chosen. \\
 \crystal{air}{12pt} & %
-\tspec{Quick Draw}: Requires level Air 3. Once per round as a free action, you can draw and switch weapons. \\
-\crystal{level}{12pt} & %
-\tspec{Killer's Garments}: Requires level 1. You may equip \tequip{medium armor}, \tequip{Bows}, and \tequip{Throwing Weapons}. \\
-\crystal{air}{12pt} \crystal{fire}{12pt} & %
-\tspec{Deadly Dance}: Requires Air level 5 and Fire level 4. Whenever you hit the \taction{Attack} action, you may lower the value of one of your initiative dice by 1, to a minimum of the current phase. \\
+\tspec{Slim Target}: Requires Air level 4. Once per round, you can use any action or reaction as an interrupt. \\
+\crystal{earth}{12pt} & %
+\tspec{Surprise Assault}: Requires Earth level 3. Whenever you declare a Slow action, you may reduce its charge time to zero by increasing another of your initiative dice's value by action's charge time. This ability fails if it would increase a die to a value of 11 or greater. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -25,36 +25,37 @@
 }
 \end{center}
 \begin{ffminipage}
-\noindent\tability{Critical Speed}: Core Ability acquired at level 19. You may add your Air level to your ARM and your Fire level to your MARM. While your current HP is 25\% of your max HP or less, you gain the \tstatus{Haste} status. You lose this status if your current HP is more than 25\% of your max HP for any reason. \pc
+\noindent\tability{Preemptive Attack}: Core Ability acquired at level 19. After rolling initiative, you may change one of your dice’s value to 1. You may add your Air level to your Armor and your Water level to your Magic Armor. \pc
 
 \begin{jobchoice}
-\crystal{earth}{12pt} \crystal{water}{12pt} & %
-\tspec{Blade Barrier}: Requires Earth and Water level 6. The best defense is a good offense. Add your Earth level to your ARM and your Water level to your MARM. \\
-\crystal{air}{12pt} \crystal{fire}{12pt} & %
-\tspec{Danger Zone}: Requires Air and Fire level 6. At the beginning of each round, you may spend HP equal to 25\% of your max HP to receive the \tstatus{Haste} status during this round. \\
-\crystal{fire}{12pt} \crystal{water}{12pt} & %
-\tspec{Two-Weapon Defense}: Requires Fire level 9 and Water level 5. You gain the reaction \taction{Double Parry}. Use when hit by a Melee \tatk{physical} attack. Do an (the greater of Air or Earth) vs Earth attack, difficulty 40. If successful, you ignore the attack’s effects. \\
+\crystal{fire}{12pt} & %
+\tspec{Magical Reflexes}:  Requires Fire level 8. You may use !Arrow Guard to avoid Spells. \\
+\crystal{earth}{12pt} \crystal{fire}{12pt} & %
+\tspec{Just a Scratch}: Requires Earth and Fire level 10. The first time in each round you suffer a critical hit, ignore the effects of critical hit (if any). The attack does its normal effects. You may still count as if it had been a critical hit for the purposes of other Abilities. \\
+\crystal{earth}{12pt} & %
+\tspec{Feign Weakness}: Requires Earth level 7. Whenever an opponent misses an attack against you or you avoid its effects by reacting, you may force the opponent to discard one initiative die and immediately repeat the attack against only you (even if the attack targets a Group, it will only target you when you use False Weakness). \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Deadly Accuracy}: Core Ability acquired at level 35. After rolling an attack, you may reduce or increase the d100 result by 1. \pc
+\noindent\tability{Total Defense}: Core Ability acquired at level 35. You may delay any number of actions, instead of only one. \pc
 
 \begin{jobchoice}
-\crystal{air}{12pt} & %
-\tspec{Deep Cut}: Requires Air level 16. When you attain a critical hit with an action that deals damage, ignore the target’s ARM and MARM. \\
-\crystal{earth}{12pt} \crystal{air}{12pt} \crystal{fire}{12pt} \crystal{water}{12pt} & %
-\tspec{Zen Focus}: Requires Earth, Air, Fire and Water level 8. At the beginning of each round, you may choose one of your initiative die’s value instead of rolling it. \\
+\crystal{air}{12pt} \crystal{water}{12pt} & %
+\tspec{Impromptu Cover}: Requires Air and Water level 13. Increase by 30 the difficulty of all Group attacks that include you as its targets. \\
+\crystal{earth}{12pt} \crystal{fire}{12pt} & %
+\tspec{Blade Barrier}: Requires Earth and Fire level 13. Add your Earth level to your Armor and your Fire level to your Magic Armor. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Fierce Assault}: Core Ability acquired at level 50. If you can act more than once on the same phase, you can perform these actions together. If you do and deal damage, you may add all damage dealt before reducing it by the target’s ARM or MARM. Regardless of how many attacks you do, reduce the ARM or MARM only once. \pc
+\noindent\tability{Air Dancer}: Core Ability acquired at level 50. Whenever an opponent misses an attack against you or you avoid its effects by reacting, you may perform the \taction{Bobbing} Ranged physical action as an interrupt. Roll Air vs Water, difficulty 40. If sucessful, the enemy loses its highest Initiative die and you gain it (with the same value). Treat this as a \tstatus{Weaken}-type status effect.  \pc
 
 \begin{jobchoice}
 \crystal{earth}{12pt} & %
-\tspec{Rain of Blows}: Requires level 18 in Earth. Once per round, after being successful with the \taction{Attack} action, you may repeat the action as a free action. \\
+\tspec{Water Dancer}: Requires Water level 18. Melee actions cannot target you unless you acted in the last 3 phases. \\
 \crystal{fire}{12pt} & %
-\tspec{Precise Hits}: Requires Fire level 18. Once per round, you may re-roll an attack when using a \tatk{physical} or \tatk{magical} action. \\
+\tspec{Fire Dancer}: Requires Air level 18. Reduce the difficulty of all actions and reactions you perform on the second or third phase by 5; on the fourth or fifth phase by 10; on the sixth or seventh phase by 15; on the eighth or ninth phase by 20 and on the tenth phase by 25. 
+\textit{(Using the scaling down optional rule, page~\pageref{subsec:scaling}, reduce the difficulty of actions and reactions on fourth, fifth and sixth phase by 1, on seventh, eighth or ninth by 2 and on tenth by 3)} \\
 \end{jobchoice}
 \end{ffminipage}

--- a/core/revised/freelancer.tex
+++ b/core/revised/freelancer.tex
@@ -3,15 +3,16 @@
 
     \textbf{Representatives}: Onion Kid (FF III), Bare Job (FF V) \pc
 
-    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=6x,mpa=1x,mpc=2x,armor=?,weapons=?]
+    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=6x,mpa=1x,mpb=2x,mpc=3x,armor=none,weapons=none]
 \end{jobdesc}
 
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Versatility}: Core Ability acquired at level 1. Your HP bonus is 3x your level, and increases by 1x your level at levels 15, 30 and 60. Your MP bonus is 1x your level, and increases by 1x your level at level 30.
+\noindent\tability{Versatility}: Core Ability acquired at level 1. Core Ability acquired at level 1. You are a freelancer, and gain the multipliers and equipment choices above.
+
 \end{ffminipage} \pc \begin{ffminipage}
-\noindent\tability{Job Change}: Core Ability acquired at level 1. Choose a Main Job. You undergo a Job Change to the chosen Job. You can equip the weapons and armor as if you had the first Ability of this Job. Each time you spend Job Points, select abilities from a job and Job Change to that job. Whenever you make a Job Change, treat as you had the new Job to determine which weapons and armor you may equip, instead of the previous. You may only keep the option to equip a piece of gear if you have an Ability that permanently grants access to a weapon or armor type. Your Main Job’s abilities other than \tability{JP UP} may not change your HP and MP bonuses. Lastly, you may not acquire any Main Job’s Specialties unless by spending Job Points.
+\noindent\tability{Job Change}: Core Ability acquired at level 1. Choose a Main Job. You undergo a Job Change from Freelancer to the chosen Job. Whenever you make a Job Change, treat as you had the new Job to determine which weapons and armor you may equip, instead of the previous. Each time you spend Job Points to acquire a new ability, you must undergo a Job Change to that job. You may only keep the option to equip a piece of gear if you have an Ability that permanently grants access to a weapon or armor type. Your Main Job’s abilities other than \tability{JP UP} may not change your HP and MP bonuses. Lastly, you may not acquire any Main Job’s Specialties unless by spending Job Points.
 \end{ffminipage} \pc \begin{ffminipage}
 \noindent\tability{JP UP}: Ability acquired at level 8. Gain 3 Job Points (JP). You may spend them accordingly to the table below. You may spend less than your total Job points but cannot spend them again until you gain more Job Points. To gain any Core Ability or Specialty this way, you must satisfy all the Ability's required levels.
 \begin{center}
@@ -19,9 +20,9 @@
     \begin{tabular}{lcl}
         \toprule
         \textbf{Ability Gained} & \textbf{JP Cost} & \textbf{Special} \\ \midrule
-        Increase your HP bonus multiplier by 1 & 1 & May be chosen once \\
-        Increase your HP bonus multiplier by 1 & 2 & May be chosen twice \\
-        Increase your MP bonus multiplier by 1 & 2 & May be chosen twice \\
+        Increase your HP bonus multiplier by 1 at all levels & 1 & May be chosen once \\
+        Increase your HP bonus multiplier by 1 at all levels & 2 & May be chosen twice \\
+        Increase your MP bonus multiplier by 1 at all levels & 2 & May be chosen twice \\
         \tability{Awakened}, \tability{Natural Domain}, \tability{Arcane Devotion} core abilities & 2 & \\
         Pick a job's first ability that grants spell groups & 2 & Other than \tability{Arcane Devotion} \\
         Pick a job's second or later ability that grants spell groups & 1 & Other than \tability{Arcane Devotion} \\

--- a/core/revised/freelancer.tex
+++ b/core/revised/freelancer.tex
@@ -9,7 +9,7 @@
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Versatility}: Core Ability acquired at level 1. Core Ability acquired at level 1. You are a freelancer, and gain the multipliers and equipment choices above.
+\noindent\tability{Versatility}: Core Ability acquired at level 1. You are a freelancer, and gain the multipliers and equipment choices above.
 
 \end{ffminipage} \pc \begin{ffminipage}
 \noindent\tability{Job Change}: Core Ability acquired at level 1. Choose a Main Job. You undergo a Job Change from Freelancer to the chosen Job. Whenever you make a Job Change, treat as you had the new Job to determine which weapons and armor you may equip, instead of the previous. Each time you spend Job Points to acquire a new ability, you must undergo a Job Change to that job. You may only keep the option to equip a piece of gear if you have an Ability that permanently grants access to a weapon or armor type. Your Main Job’s abilities other than \tability{JP UP} may not change your HP and MP bonuses. Lastly, you may not acquire any Main Job’s Specialties unless by spending Job Points.

--- a/core/revised/jobs.tex
+++ b/core/revised/jobs.tex
@@ -65,7 +65,7 @@ These ranks, are, however, just an approximation of each Job's Abilities. If you
 \subsection{Archer}\label{subsec:pjob-archer}
 \input{revised/archer.tex}
 
-\section{Artist}\label{subsec:pjob-artist}
+\subsection{Artist}\label{subsec:pjob-artist}
 \input{revised/artist.tex}
 
 \subsection{Black Mage}\label{subsec:pjob-blackmage}

--- a/core/revised/monk.tex
+++ b/core/revised/monk.tex
@@ -45,7 +45,7 @@
 \tspec{Vengeful Spirits}: Requires Fire level 6 and Water level 4. Whenever your Jutsu are successful, consider that they had a critical hit. \\
 \crystal{earth}{12pt} \crystal{fire}{12pt} & %
 \tspec{Lightning Jutsu}: Requires Earth level 4 and Fire level 6. You gain the \actype[reaction=true] \taction{Raiton}. Use it when you are hit by a magical action or Spell. You conjure the spirits defensively to interfere with it. Perform a Fire vs Fire attack, difficulty 40. A successful reaction means you ignore the action's damage. You may also use this reaction to negate all effects of the magical action or Spell, when you or an ally is hit by a magical action or Spell that deals elemental damage opposed to one of your earned Jutsu, according to the table below. \\
-\begin{center}
+\multicolumn{2}{c}{
     \rowcolors{1}{gray!10}{}
     \begin{tabular}{ll}
         \toprule
@@ -54,9 +54,9 @@
         \taction{Suiton} & \telem{Fire} or \telem{Light} \\
         \taction{Doton} & \telem{Air} or \telem{Lightning} \\
         \taction{Fuuton} & \telem{Earth} or \telem{Shadow} \\ \bottomrule
-    \end{tabular}
-\end{center}
+    \end{tabular} }
 \end{jobchoice}
+
 \end{ffminipage}
 
 \begin{ffminipage}

--- a/core/revised/monk.tex
+++ b/core/revised/monk.tex
@@ -16,9 +16,11 @@
 \crystal{earth}{12pt} & %
 \tspec{Brawler}: Requires Earth level 3. Whenever you use the \taction{Attack} action while equipped with \tequip{Claws / Gloves}, you may re-roll the attack once. \\
 \crystal{air}{12pt} & %
-\tspec{Drunken Dodge}: Requires Air level 3. Whenever an enemy attack or spell against you fails (because it missed or because you successfully avoided it), you may lower the value of one of your initiative dice by 1, to a minimum of the current phase. \\
+\tspec{Drunken Dance}: Requires Air level 3. Whenever you perform a physical action, reduce your next action's charge time by 2, to a minimum of zero, if it is magical. Whenever you perform a magical action, reduce your next action's charge time by 2, to a minimum of zero, if it is physical. \\
+\crystal{fire}{12pt} & %
+\tspec{Spirit Power}: Requires Fire level 3. Whenever one of your abilities’ effects change based on your character level, consider it as being four levels higher than it is. Reduce all Stat level of your Specialties’ (both earned and unearned) requirements by one. \\
 \crystal{water}{12pt} & %
-\tspec{Elemental Arts}: Requires Water level 3. Your MP bonus becomes equal to your level (if not already higher). In addition, you gain access to one of the following Spell groups: \tspellgroup{Gravity}, \tspellgroup{Healing}, \tspellgroup{Poison}, or \tspellgroup{Purify} \\
+\tspec{Elemental Arts}: Requires Water level 3. Increase your MP bonus multiplier at all levels by 1 if its level 1 value is zero. In addition, you gain access to one of the following Spell groups: \tspellgroup{Gravity}, \tspellgroup{Healing}, \tspellgroup{Poison}, or \tspellgroup{Purify}. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -27,91 +29,92 @@
 
 \begin{jobchoice}[header=false]
 \crystal{level}{12pt} & %
-\taction{Katon} is a Ranged Slow (3) \tatk{magical} action. Using it, you invoke elemental spirits. Do a Fire vs Fire attack, difficulty 40. If successful, deal 4x Fire level \telem{Fire}-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Sleep} status until the end of the next round. \\
+\taction{Katon} is a Ranged Slow (3) \tatk{magical} action. Using it, you invoke elemental spirits. Do a Fire vs Fire attack, difficulty 40. If successful, deal 4x Fire level Fire-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Curse} status until the end of the next round. At level 20 or greater, critical hits also inflict the \tstatus{Sleep} status until the end of the next round. \\
 \crystal{level}{12pt} & %
-\taction{Suiton} is a Ranged Slow (3) \tatk{magical} action. Using it, you invoke elemental spirits. Do a Fire vs Water attack, difficulty 40. If successful, deal 4x Fire level \telem{Water}-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Weaken (Mental)} status until the end of the next round. \\
+\taction{Suiton} is a Ranged Slow (3) \tatk{magical} action. Using it, you invoke elemental spirits. Do a Fire vs Water attack, difficulty 40. If successful, deal 4x Fire level Water-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Weaken (Mental)} status until the end of the next round. At level 20 or greater, critical hits also inflict the \tstatus{Mute} status until the end of the next round. \\
 \crystal{level}{12pt} & %
-\taction{Doton} is a Ranged Slow (3) \tatk{magical} action. Using it, you invoke elemental spirits. Do a Fire vs Earth attack, difficulty 40. If successful, deal 4x Fire level \telem{Earth}-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Poison} status until the end of the next round. \\
+\taction{Doton} is a Ranged Slow (3) \tatk{magical} action.  Using it, you invoke elemental spirits. Do a Fire vs Earth attack, difficulty 40. If successful, deal 4x Fire level Earth-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Poison} status until the end of the next round. At level 20 or greater, critical hits also inflict the \tstatus{Virus} status until the end of the next round. \\
 \crystal{level}{12pt} & %
-\taction{Fuuton} is a Ranged Slow (3) magical action. Using it, you invoke elemental spirits. Do a Fire vs Air attack, difficulty 40. If successful, deal 4x Fire level \telem{Air}-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Blind} status until the end of the next round. \\
+\taction{Fuuton} is a Ranged Slow (3) magical action. Using it, you invoke elemental spirits. Do a Fire vs Air attack, difficulty 40. If successful, deal 4x Fire level Air-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Blind} status until the end of the next round. At level 20 or greater, critical hits also inflict the \tstatus{Confuse} status until the end of the next round. \\
 \end{jobchoice} \pc
 
 \begin{jobchoice}
 \crystal{air}{12pt} \crystal{fire}{12pt} & %
-\tspec{Elan}: Requires Air level 4 and Fire level 7. Your Jutsu targets a group instead of just one target. \\
+\tspec{Elan}: Requires Air level 4 and Fire level 6. Your Jutsu targets a group instead of just one target. \\
 \crystal{fire}{12pt} \crystal{water}{12pt} & %
-\tspec{Vengeful Spirits}: Requires Fire level 7 and Water level 4. Whenever your Jutsu are successful, consider that they had a critical hit. \\
+\tspec{Vengeful Spirits}: Requires Fire level 6 and Water level 4. Whenever your Jutsu are successful, consider that they had a critical hit. \\
 \crystal{earth}{12pt} \crystal{fire}{12pt} & %
-\tspec{Lightning Jutsu}: Requires Earth level 4 and Fire level 7. You gain the reaction \taction{Raiton}. Use it you are hit by a damaging action. You conjure the spirits defensively to interfere with it. Perform a Fire vs Fire attack, difficulty 20. The action causes no effect if either you have the \taction{Katon} Jutsu and the action's damage is \telem{Water} or \telem{Ice}-elemental; or you have the \taction{Suiton} Jutsu and the action's damage is \telem{Fire} or \telem{Light}-elemental; or you have the \taction{Doton} Jutsu and the action's damage is \telem{Air} or \telem{Lightning}-elemental; or you have the \taction{Fuuton} Jutsu and the action's damage is \telem{Earth} or \telem{Shadow}-elemental. \\
+\tspec{Lightning Jutsu}: Requires Earth level 4 and Fire level 6. You gain the \actype[reaction=true] \taction{Raiton}. Use it when you are hit by a magical action or Spell. You conjure the spirits defensively to interfere with it. Perform a Fire vs Fire attack, difficulty 40. A successful reaction means you ignore the action's damage. You may also use this reaction to negate all effects of the magical action or Spell, when you or an ally is hit by a magical action or Spell that deals elemental damage opposed to one of your earned Jutsu, according to the table below. \\
+\begin{center}
+    \rowcolors{1}{gray!10}{}
+    \begin{tabular}{ll}
+        \toprule
+        \textbf{Jutsu} & \textbf{Opposing Elements} \\ \midrule
+        \taction{Katon} & \telem{Ice} or \telem{Water} \\
+        \taction{Suiton} & \telem{Fire} or \telem{Light} \\
+        \taction{Doton} & \telem{Air} or \telem{Lightning} \\
+        \taction{Fuuton} & \telem{Earth} or \telem{Shadow} \\ \bottomrule
+    \end{tabular}
+\end{center}
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-    \noindent\tability{Serenity}: Core Ability acquired at level 15. You gain resistance to \tstatus{Mental} type statuses. \pc
+    \noindent\tability{Punch Rush}: Core Ability acquired at level 15. You gain the Slow (3) action !Punch Rush. Perform a weapon attack, difficulty 30, dealing weapon damage and ignoring half of the target's Armor or Magical Armor. Reduce by 10 the difficulty if your weapon deals physical damage. Reduce by 10 the difficulty if your weapon is not Ranged. \taction{Punch Rush} attacks with \tequip{Claws/Gloves} ignores the target's Armor. \pc
 
     \begin{jobchoice}
     \crystal{fire}{12pt} & %
-    \tspec{Jutsu Acolyte}: Requires Fire level 6. You gain one of the following Jutsu: \taction{Katon}, \taction{Suiton}, taction{Doton}, or \taction{Fuuton}. \\
+    \tspec{Jutsu Acolyte}: Requires Fire level 7. You gain one of the following Jutsu: \taction{Katon}, \taction{Suiton}, taction{Doton}, or \taction{Fuuton}. \\
     \crystal{air}{12pt} & %
-    \tspec{Flurry of Blows}: Requires Air level 8. You gain the Quick \tatk{physical} action \taction{Punch Rush}. It can be used only if you’re equipped with \tequip{Claws / Gloves} and can perform two actions in the same phase. Attacking your opponent with superhuman speed, you spend all initiative dice needed to perform two actions and strike an Earth vs Air attack, difficulty 40. This attack deals 300\% weapon damage in one target. \\
+    \tspec{Zen Awareness}: Requires Air level 8. You may use reactions while charging Slow actions as an interrupt. \\
     \crystal{earth}{12pt} & %
-    \tspec{Swivel Kick}: Requires Earth level 8. You gain the Quick action \taction{Kick}. When using it, attack all opponents with your weapon. After reducing your weapon damage by targets’ ARM or MARM as usual, reduce the damage by half. This action ignores the \tstatus{Protect} and
-    \tstatus{Elemental Resist} status effects on the targets. \\
+    \tspec{Flurry of Blows}: Requires Earth level 7. Your attacks hit when you roll doubles, even if the attack didn’t overcome the difficulty. Your \taction{Punch Rush} can critical hit, dealing double damage and inflicting the \tstatus{Weaken (Armor)} status effect until the end of the round. \\
     \end{jobchoice}
     \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Soul Volley}: Core Ability acquired at level 24. You gain one of the three following actions: \pc
+\noindent\tability{Zen Evasion}: Core Ability acquired at level 24. You gain the \actype[reaction=true] \taction{Zen Evasion}. Use it after you're hit with a Slow action. You ignore the action's effects on a successful Air vs Fire roll, difficulty 40. \pc
+
+\begin{jobchoice}
+\crystal{fire}{12pt} \crystal{water}{12pt} & %
+\tspec{Aura Bolt}:  Requires Fire and Water level 10. Choose and gain either \taction{Aura Bolt} or \taction{Dark Bolt}. Both are \textit{Ranged} Slow (4) magical actions. Release your inner Chi in a bolt of light or darkness to perform a Fire vs Water attack, difficulty 50. If successful, the target takes 14 x Fire level damage, and you may repeat the attack as an interrupt any number of times, each against a different target. \taction{Aura Bolt} deals \telem{Light}-elemental damage and \taction{Dark Bolt} deals \telem{Shadow}-elemental damage. At level 45 the damage increases to 16 x Fire level damage, at level 52 it increases to 20x Fire level damage, and at level 59 it increases to 22x Fire level damage. \\
+\crystal{earth}{12pt} \crystal{air}{12pt} \crystal{fire}{12pt} \crystal{water}{12pt} & %
+\tspec{Timeless Body}: Requires Earth, Air, Fire and Water level 8. You resist \tstatus{Mental}-type and \tstatus{Time}-type status effects. \\
+\crystal{earth}{12pt} & %
+\tspec{Suplex}: Requires Earth level 10. When using the \taction{Punch Rush} action, you may discard an extra initiative die to deal 300\% weapon damage on normal and critical hits. The damage is only 200\% weapon damage if you're equipped with any weapon other than \tequip{Claws/Gloves}. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+\noindent\tability{Awaken Chakra}: Core Ability acquired at level 42. Choose one of the three options below: \pc
 
 \begin{jobchoice}[header=false]
 \crystal{level}{12pt} & %
-\taction{Aura Bolt} is a Ranged Slow (4) \tatk{magical} action. You release a wave of light against an opponent, performing a Fire vs Water attack, difficulty 50. If successful, the target takes 13x Fire level \telem{Light}-elemental damage. At level 50, the damage becomes 20 x Fire level. \\
+\textit{Balanced Chakras}: Whenever you use an action or reaction which Offensive Stat is Earth or Fire, you may use the highest of either Earth or Fire. \\
 \crystal{level}{12pt} & %
-\taction{Dark Bolt} is a Ranged Slow (4) \tatk{magical} action. You release a wave of darkness against an opponent, performing a Fire vs Water attack, difficulty 50. If successful, the target takes 13x Fire level \telem{Shadow}-elemental damage. At level 50, the damage becomes 20 x Fire level. \\
+\textit{Spiritual Chakras}: When using a Jutsu or Soul Volley, you may increase its charge time by 1 to increase the damage by 3x Fire level on a single target, or by 1x Fire level on all targets. \\
+\crystal{level}{12pt} & %
+\textit{Material Chakras}: You gain the Slow (2) action \taction{Kick}. When using it, attack all opponents with your weapon, dealing 100\% weapon damage. When equipped with \tequip{Claws/Gloves}, ignore the target's Protect status. \\
 \end{jobchoice}
 
 \begin{jobchoice}
 \crystal{earth}{12pt} \crystal{water}{12pt} & %
-\tspec{Awaken Chakra}: Requires Earth and Water level 10. You gain the Slow (5) \tatk{magical} action \taction{Chakra}. When using it, you release the healing power of your Chakra to end any negative statuses affecting you. However, you can’t use this Ability while under the effect of any \tstatus{Mental} type status. \\
+\tspec{Pressure Points}: Requires Earth level 6 and Water level 12. You gain the Slow (2) physical action \taction{Atemi}. This action allows you to deliver blows to the correct points to close the chakra of the target. Do an Earth vs Earth attack, difficulty 70. If successful, inflict the Immobilize status until the end of the next round. At level 50, reduce the difficulty to 50. You may spend 30 MP to make your \taction{Atemi} action targets all enemies instead of only one. \\
 \crystal{air}{12pt} \crystal{water}{12pt} & %
-\tspec{Pressure Points}: Requires Air level 6 and Water level 12. You gain the Slow (2) \tatk{physical} action \taction{Atemi}. This action allows you to deliver blows to the correct points to close the chakra of the target. Do an Earth vs Earth attack, difficulty 70. If successful, inflict the \tstatus{Immobilize} status until the end of the next round. \\
-\crystal{earth}{12pt} & %
-\tspec{Suplex}: Requires Earth level 13. If you hit the same opponent with the \taction{Attack} action twice in a phase with a \tequip{Claw / Glove} equipped, you inflict the \tstatus{Confuse} status until the end of the round. If you have the \tability{Flurry of Blows} ability, your \taction{Punch Rush} action inflicts the \tstatus{Confuse} status until the end of the round, in addition to damage. \\
+\tspec{Release Chakra}: Requires Air level 6 and Water level 12. You gain the Slow (5) magical action \taction{Chakra}. When using it, you release the healing power of your chakras to end any negative statuses affecting you. However, until level 50, you can’t use this Ability while under the effect of any \tstatus{Mental}-type or \tstatus{Time}-type negative statuses. You may spend any amount of MP to recover HP equal to double of that amount, in addition to its effects. \\
+\crystal{fire}{12pt} \crystal{water}{12pt} & %
+\tspec{Chi Blast}: Requires Fire level 6 and Water level 12. You gain the Slow (2) magical action \taction{Chi Blast}. This action allows you to directly attack the enemy's fighting spirit. Do an Fire vs Fire attack, difficulty 70. If successful, inflict the \tstatus{Disable} status until the end of the next round. At level 50, reduce the difficulty to 50. You may spend 30 MP to make your \taction{Chi Blast} action targets all enemies instead of only one. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Release Chakra}: Core Ability acquired at level 42. Choose one of the four advantages below: \pc
-
-\begin{jobchoice}[header=false]
-\crystal{level}{12pt} & %
-When using the \taction{Chakra} action, you may spend any amount of MP to recover HP equal to double of that amount, in addition to its effects. \\
-\crystal{level}{12pt} & %
-When you hit the \taction{Atemi} action, you may spend 40 MP to inflict the \tstatus{Disable} status to the target until the end of the next round, in addition to its effects. \\
-\crystal{level}{12pt} & %
-When using a Jutsu, you may spend 40 MP to increase the damage to 16x Fire level. \\
-\crystal{level}{12pt} & %
-Whenever you use a Slow (X) action without MP costs, you may spend MP equal to 15 times the X number to make it a Quick action instead. For example, it costs 60 MP to cast \taction{Aura Bolt} as Quick Action.
-\end{jobchoice}
-
-\begin{jobchoice}
-\crystal{earth}{12pt} \crystal{fire}{12pt} & %
-\tspec{Soul Explosion}: Requires Earth and Fire level 12. After using the \taction{Aura Bolt} or \taction{Dark Bolt} actions, you may discard any number of initiative dice regardless of their value, to immediately repeat the attack once per discarded die against a different target. \\
-\crystal{air}{12pt} & %
-\tspec{Zen Awareness}: Requires Air level 13. You may use reactions while preparing Slow actions. \\
-\crystal{earth}{12pt} \crystal{air}{12pt} \crystal{fire}{12pt} \crystal{water}{12pt} & %
-\tspec{Elemental Field}: Requires Earth, Air, Fire and Water level 8. After using a Jutsu, you and the target gain the \tstatus{Resist} status to until the end of the round. The element depends on the Jutsu used: \taction{Katon} confers resistance to \telem{Water}; \taction{Suiton} confers resistance to \telem{Fire}; \taction{Doton} gives \telem{Air} resistance; and \taction{Fuuton} gives resistance to \telem{Earth}. If you have the \tability{Elan} Ability, all combatants, allies and enemies, gain the \tstatus{Resist} status. \\
-\end{jobchoice}
-\end{ffminipage}
-
-\begin{ffminipage}
-\noindent\tability{Timeless Body}: Core Ability acquired Base at level 60. You resist \tstatus{Time} type statuses. \pc
+\noindent\tability{Zen Mind}: Core Ability acquired Base at level 60. Your attacks and reactions against enemies suffering any negative status effects may be rerolled once. \pc
 
 \begin{jobchoice}
 \crystal{fire}{12pt} & %
 \tspec{Jutsu Master}: Requires Fire level 20. You gain two of the following actions: \taction{Katon}, \taction{Suiton}, \taction{Doton} or \taction{Fuuton}. You also gain the Ranged Slow (5) \tatk{magical} action \taction{Kuuton}. Using your mastery of the four elements, roll 1d100 and add your Fire value, comparing this result to all opponents’ stats. If the result is greater than Earth plus 20, the opponent takes 6x Fire level \telem{Earth}-elemental damage. If the result is greater than Air plus 20, the opponent takes 6x Fire level \telem{Air}-elemental damage. If the result is greater than Fire plus 20, the opponent takes 6x Fire level \telem{Fire}-elemental damage. If the result is greater than Water plus 20, the opponent takes 6x Fire level \telem{Water}-elemental damage. This attack always ignores targets’ MARM. \\
 \crystal{air}{12pt} \crystal{water}{12pt} & %
-\tspec{Elemental Union}: Requires Air and Water level 10. Increase your MP bonus by 1 times your level. You gain one of the following Spell groups: \tspellgroup{Mage Bane}, \tspellgroup{Regeneration}, \tspellgroup{Enchantment}, or \tspellgroup{Divination}. \\
+\tspec{Elemental Union}: Requires Air and Water level 10. Increase your MP bonus multiplier by 1 at all levels. You gain one of the following Spell groups: \tspellgroup{Mage Bane}, \tspellgroup{Regeneration}, \tspellgroup{Enchantment}, or \tspellgroup{Divination}. \\
 \crystal{earth}{12pt} & %
 \tspec{Phantom Rush}: Requires Earth level 20. You gain the Slow (6) \tatk{physical} action \taction{Phantom Rush}, a martial arts secret known as the supreme blow. Using it, do an Earth vs Air attack, difficulty 30. If successful, deal 33x Earth level \telem{Crush}-elemental damage on a target, ignoring its ARM. \\
 \end{jobchoice}

--- a/core/revised/performances.tex
+++ b/core/revised/performances.tex
@@ -8,7 +8,7 @@
     
     \textit{Toxic Dance} is a level 1 dance. Perform a Water vs Earth attack, difficulty 70. If successful, inflict the \tstatus{Poison} status on a target during this and the next three rounds.
 
-    \textit{Darkness Dance} is a level 1 dance. Perform a Water vs Fire attack, difficulty 70. If successful, inflict the \tstatus{Blind} status on a target until the end of next round.
+    \textit{Darkness Dance} is a level 1 dance. Perform a Water vs Fire attack, difficulty 70. If successful, inflict the \tstatus{Curse} status on a target until the end of next round.
     
     \textit{Temptation Tango} is a level 2 dance. Perform a Water vs Fire attack, difficulty 70. If successful, inflict the \tstatus{Confuse} status on a target until the end of next round.
     

--- a/core/revised/phalanx.tex
+++ b/core/revised/phalanx.tex
@@ -7,15 +7,15 @@
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Impenetrable}: Core Ability acquired Base at level 1. You may equip \tequip{heavy armor} and gain the reaction \taction{Third Eye}. When you are hit by a Melee attack, perform an Earth vs Air attack, difficulty 40. If you are successful, the attack fails. This does not affect Spells. \pc
+\noindent\tability{Impenetrable}: Core Ability acquired Base at level 1. You may equip \tequip{heavy armor} and gain the \actype[reaction=true] \taction{Third Eye}. When you are hit by a Melee attack, perform an Earth vs Air attack, difficulty 40. If you are successful, the attack fails. This does not affect Spells. \pc
 
 \begin{jobchoice}
 \crystal{earth}{12pt} & %
-\tspec{Martial Training}: Requires Earth level 3. Choose two types of weapons: \tequip{Heavy Weapon}, \tequip{Polearm}, \tequip{Heavy Weapon \& Shield}, \tequip{Katana}, or \tequip{Throwing Weapons}. You may equip the selected weapons. \\
+\tspec{Martial Training}: Requires Earth level 2. Choose two types of weapons other than \tequip{Twin Blades} or \tequip{Instruments}. You may equip the selected weapons. \\
 \crystal{air}{12pt} & %
-\tspec{Excessive Force}: Requires Air level 5. Whenever you deal a critical hit against an opponent preparing a Slow action, cancel the Slow action. \\
+\tspec{Huge Target}: Requires Air level 4. During any round in which you succeed with \taction{Third Eye}, all enemies add 20 to the difficulty of all attacks and spells that does not target you. This ability have no effects while there are two or more characters with this ability in the same party and does not stack with itself. \\
 \crystal{fire}{12pt} & %
-\tspec{Willpower}: Requires Fire level 5. If your HP bonus multiplier is lower than 5, increase it by one. Use the greater between Earth and Fire Values to calculate your HP. \\
+\tspec{Willpower}: Requires Fire level 5. Increase your HP bonus multiplier at all levels by 1 if its level 1 value is 4x or lower. Use the greater between Earth and Fire Values to calculate your HP. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -24,22 +24,30 @@
 
 \begin{jobchoice}
 \crystal{earth}{12pt} & %
-\tspec{Inspiring Courage}: Requires Earth level 12. While your current HP is 25\% of your max HP or less, your allies gain the \tstatus{Protect} status. Your allies lose this status if your current HP is more than 25\% of your max HP for any reason. \\
+\tspec{Inspiring Courage}: Requires Earth level 8. While your current HP is 25\% of your max HP or less, your allies gain the \tstatus{Protect} status. Your allies lose this status if your current HP is more than 25\% of your max HP for any reason. \\
 \crystal{water}{12pt} & %
-\tspec{Preventative Defense}: Requires Water level 15. Your \tability{Tireless} ability activate when your current HP is 50\% of maximum, instead of 25\%. \\
-\crystal{fire}{12pt} & %
-\tspec{Bonebreaker}: Requires Fire level 10. Once per phase, if your current HP is 25\% of your max HP or less when you use the \taction{Attack} action against an opponent that dealt you \tatk{physical} damage this phase, you deal 150\% weapon damage if it is not a critical hit. \\
+\tspec{Preventive Defense}: Requires Water level 9. Your \tability{Tireless} ability activate when your current HP is 50\% of maximum, instead of 25\%. \\
+\crystal{air}{12pt} \crystal{fire}{12pt} & %
+\tspec{Testudo Formation}: Requires Fire and Air level 7. You gain the free \actype[reaction=true] \taction{Testudo}. Use it whenever an enemy performs an attack against one of your allies that does not target you. Roll Earth vs highest Stat, dif 40, to negate the action. You may only use this reaction once per enemy attack and only if no enemy used a Melee attack on you this round. \\
+\tspec{Shield Wall}: Requires Earth level 9. You gain the \actype[reaction=true] \taction{Shield Wall}. When you and at least one ally is targetted by an action that deals physical damage, perform an Earth vs Fire roll, difficulty 0, to redirect all attacks to you. You may, as a free action, use another reaction once per attack that hits you. \\
 \end{jobchoice}
 \end{ffminipage}
 
 \begin{ffminipage}
-\noindent\tability{Unshakable}: Core Ability acquired at level 35. You gain the reaction \taction{Shield Wall}. When you and at least one ally is hit by an attack that deals \tatk{physical} damage, perform an Earth vs Fire attack, difficulty 70. Your allies don’t suffer the attack’s effects regardless of the die result. If you fail, for each of the attack’s targets, you suffer the attack’s effects once. If you are successful, for each of the attack’s targets, you suffer the 50\% of attack’s damage. If you have a critical hit, you suffer the attack’s effects only once. \pc
+\noindent\tability{Unshakable}: Choose one of the following options: \pc
+
+\begin{jobchoice}[header=false]
+\crystal{level}{12pt} & %
+Each time you're hit with a physical attack, the enemy that performed the action takes physical \telem{Puncture}-elemental damage equal to your HP bonus multiplier times your Earth level.  \\
+\crystal{level}{12pt} & %
+Increase your HP bonus multiplier at all levels by 1 if its level 1 value is 5x or lower. \\
+\end{jobchoice} 
 
 \begin{jobchoice}
 \crystal{fire}{12pt} \crystal{water}{12pt} & %
-\tspec{Runic Shield}: Requires Fire and Water level 12. You may use your \taction{Shield Wall} reaction against magical damage attacks. \\
+\tspec{Runic Shield}: Requires Fire and Water level 12. You may use \taction{Third Eye} against Spells. You may use \taction{Shield Wall} against magical damage attacks if you have it. \\
 \crystal{earth}{12pt} \crystal{air}{12pt} & %
-\tspec{Reinforced Shield}: Requires Earth and Air level 13. Whenever you are successful with the \taction{Shield Wall} reaction, you gain the \tstatus{Strengthen (Armor)} status until the end of the round. \\
+\tspec{Armor Specialist}: Requires Earth and Air level 13. While you wear heavy armor, you gain Auto-\tstatus{Strenghten(Armor)} and your \taction{Third Eye}'s difficulty is 0 against physical attacks. While you wear light armor, you gain Auto-\tstatus{Strenghten(Mental)} and your \taction{Third Eye}'s difficulty is 0 against magical attacks. While you wear medium armor, you may once per phase use any reaction as an interrupt. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -48,8 +56,8 @@
 
 \begin{jobchoice}
 \crystal{earth}{12pt} & %
-\tspec{Scream}: Requires Earth level 18. You gain the reaction \taction{Scream}. Use it when you suffer an attack that inflicts a negative status effect. Perform a Water vs (the greater between Air or Fire) attack, difficulty 70. If successful, the attack doesn’t inflict any negative status and, if the attack did damage, you recover HP equal to twice the damage dealt. \\
+\tspec{Scream}: Requires Earth level 18. You gain the reaction \taction{Scream}. Use it when you suffer an attack that inflicts a negative status effect. Perform a Water vs (the greater between Air or Fire) attack, difficulty 40. If successful, the attack doesn’t inflict any negative status and, if the attack did damage, you recover HP equal to twice the damage dealt after reducing by your ARM or MARM. \\
 \crystal{water}{12pt} & %
-\tspec{Uncontrollable}: Requires Water level 18. You gain the Slow (3) \tatk{physical} action \taction{Meatbone Slash}. Putting all your weight behind the strike, you perform a weapon attack. If successful, the target takes damage equal to your maximum HP, or 999, whichever is less. \\
+\tspec{Uncontrollable}: Requires Water level 18. You gain the Slow (4) \tatk{physical} action \taction{Meatbone Slash}. Putting all your weight behind the strike, you perform a weapon attack. If successful, the target takes damage equal to your current HP, or 999, whichever is less. This attack ignores the Armor of any targets that did not attacked you this round. \\
 \end{jobchoice}
 \end{ffminipage}

--- a/core/revised/rogue.tex
+++ b/core/revised/rogue.tex
@@ -3,13 +3,13 @@
 
     \textbf{Representatives}: Cid Pollendina (FFIV), Edgar Roni Figaro (FFVI), Setzer Gabbiani (FFVI), Cait Sith (FFVII), Selphie Tilmitt (FFVIII), Wakka (FFX), Lady Luck Dressphere (FFX-2), Corsair Job (FFXI), Rikku (FFX), Gadgeteer Job (FFTA), Mustadio Bunanza (FFT), Locke Cole (FFVI), Yuffie Kisaragi (FFVII), Rikku (FFX), Thief Job (FFI, FFIII, FFV, FFXI, FFT, FFTA, FFX-2), Zidane Tribal (FFIX) \pc
 
-    \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=0x,mpc=1x,armor=Medium,weapons=\tequip{Claws / Gloves} \\ \tequip{Wands} \\ \tequip{Throwing Weapons}] 
+    \jobstats[hpa=4x,hpb=5x,hpc=6x,hpd=7x,mpa=0x,mpb=1x,mpc=2x,armor=Medium,weapons= \tequip{Polearms} \\ \tequip{Light Swords / Knives} \\ \tequip{Katana} \\ \tequip{Rifles / Crossbows} \\ and \tequip{Throwing Weapons}] 
 \end{jobdesc}
 
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\tability{Survivalist}: Core Ability acquired at level 1. You can equip \tequip{medium armor}, and the following weapons: \tequip{Polearms}, \tequip{Light Swords / Knives}, \tequip{Katana}, \tequip{Rifles / Crossbows}, and \tequip{Throwing Weapons}. Your HP bonus is 4 times your level, the multiplier increasing by 1 at levels 15, 30 and 60. Your bonus MP is zero, and increases by 1 times your level at level 30. \pc
+\tability{Survivalist}: Core Ability acquired at level 1. You are a rogue, and gain the multipliers and equipment choices above. \pc
 
 \begin{jobchoice}
 \crystal{air}{12pt} & %
@@ -61,7 +61,7 @@
 
 \tstatus{Auto: Resistance}, \tstatus{Vulnerability}, \tstatus{Immunity}, or \tstatus{Absorption} of \telem{Crush}, \telem{Puncture}, or \telem{Cut} can be exchanged for another of these three elements. \tstatus{Auto: Resistance}, \tstatus{Vulnerability}, \tstatus{Immunity} or \tstatus{Absorption} of other elements can be exchanged for another element, except \telem{Crush}, \telem{Puncture}, or \telem{Cut}. The weapons who give extra damage based on a Stat can change it to another Stat, except the weapon’s Offensive Stat. Finally, \tstatus{Auto: Status}, \tstatus{SOS: Status}, \tstatus{Status Resistance}, \tstatus{Status Immunity}, \tstatus{Status Touch}, and \tstatus{Status Strike} can swap the Status within the following power levels, changing a positive status to another positive status and a negative status effect to another negative status effect:
 
-I: \tstatus{Sleep}, \tstatus{Blind}, \tstatus{Strengthen (Speed)}, \tstatus{Weaken (Speed)}, \tstatus{Poison}, or \tstatus{Float}.
+I: \tstatus{Sleep}, \tstatus{Curse}, \tstatus{Blind}, \tstatus{Strengthen (Speed)}, \tstatus{Weaken (Speed)}, \tstatus{Poison}, or \tstatus{Float}.
 
 II: \tstatus{Weaken (Armor)}, \tstatus{Weaken (Mental)}, \tstatus{Weaken (Physical)}, \tstatus{Weaken (Magic)}, \tstatus{Strengthen (Armor)}, \tstatus{Strengthen (Mental)}, \tstatus{Strengthen (Magic)}, \tstatus{Strengthen (Physical)}, \tstatus{Immobilize}, or \tstatus{Slow}.
 

--- a/core/revised/runeknight.tex
+++ b/core/revised/runeknight.tex
@@ -7,17 +7,15 @@
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\noindent\tability{Defensive Runes}: Ability acquired Base at level 1. You may equip \tequip{light armor} and gain the reaction \taction{Runic}. Use it when hit by a Spell or a \tatk{magical} attack. Perform a Fire vs Fire attack, difficulty 40. If successful, the attack or Spell has no effect. \pc
+\noindent\tability{Defensive Runes}: Ability acquired Base at level 1. You may equip \tequip{light armor} and gain the \actype[reaction=true] \taction{Runic}. Use it when hit by a Spell or a \tatk{magical} attack. Perform a Fire vs Fire attack, difficulty 40 to negate all effects of the attack or Spell. \pc
 
 \begin{jobchoice}
-\crystal{water}{12pt} & %
-\tspec{Magic Drain}: Requires Water level 4. If you succeed with \taction{Runic}, recover the same amount of MP spent by the opponent. \\
-\crystal{fire}{12pt} & %
-\tspec{Runic Area}: Requires Fire level 5. Your \taction{Runic} reaction may also be used when a Spell or \tatk{magical} attack hits an ally. \\
-\crystal{air}{12pt} & %
-\tspec{Offensive Runes}: Requires Air level 4. Your \taction{Runic} reaction may also be used when a Spell or \tatk{magical} attack hits an opponent. \\
 \crystal{earth}{12pt} & %
-\tspec{Exotic Runes}: Requires Earth level 3. When using your \taction{Runic} reaction, you may swap the Offensive Stat to Air or Water. If you do, reduce the reaction's difficulty by 10. \\
+\tspec{Magic Drain}: Requires Earth level 3. When using \taction{Runic}, you may swap the Offensive Stat to Air or Water to reduce the reaction's difficulty by 10. In addition, whenever you succeed with \taction{Runic}, recover the same amount of MP spent by the opponent. \\
+\crystal{fire}{12pt} & %
+\tspec{Runic Area}: Requires Fire level 5. Your \taction{Runic} may also be used when a Spell or \tatk{magical} attack hits an ally. \\
+\crystal{air}{12pt} & %
+\tspec{Offensive Runes}: Requires Air level 4. Your \taction{Runic} may also be used when a Spell or \tatk{magical} attack hits an opponent. \\
 \end{jobchoice}
 \end{ffminipage}
 

--- a/core/revised/setup.tex
+++ b/core/revised/setup.tex
@@ -148,6 +148,12 @@ During character creation, each player can spend 200 Gil in equipment and items.
 Calculate your HP by adding your Earth value to your Job HP bonus and your MP by adding your Water value to your Job MP bonus using your Job's guidelines. Don't forget to flesh out the character concept using all the cues you've been collecting thus far (Traits, Quirks, Jobs, Skills, etc.). Take notes on your character backstory, motivations, personality and appearance, as that may help you roleplay your character to its fullest potential.
 
 \end{enumerate}
+\begin{boco}
+Optional Rule: \textbf{Skilled Rookies}
+
+Should you want to have starting characters with more skills so the players have more can express their character concept with more skill choices early, give them 4 skills points at character creation plus 1 extra skill point for each 4 levels (instead of 1 point per 3 levels). This should give a starting character 6 skill points instead of 2, and will level out by level 48. You're trading more skills at high (49 and over) levels for more skills at lower (48 and under) levels.
+
+\end{boco}
 \end{multicols}
 
 \begin{multimog}

--- a/core/revised/spells.tex
+++ b/core/revised/spells.tex
@@ -575,7 +575,7 @@ These more powerful spells begin to reveal the true power of Blue Mage. They are
     
     \textit{Basic Call}: Minimum Level: \ordinalnum{14} MP Cost: 20. Roll Fire vs Water, difficulty 0. If successful, deal 7 x Fire level \telem{Air}-elemental magical damage to a group.
     
-    \textit{Greater Call}: Minimum Level: \ordinalnum{34} MP Cost: 60. You and up to three allies gain the \tstatus{Flight} status. At each affected character’s next action, the character descends on a target, discards the initiative die and unleashes a weapon attack dealing twice weapon physical damage. After this attack, the character loses the \tstatus{Flight} status.
+    \textit{Greater Call}: Minimum Level: \ordinalnum{34} MP Cost: 60. You and up to three allies gain the \tstatus{Flight} status. At each affected character’s next action, the character descends on a target, discards the initiative die and unleashes a weapon attack dealing increased weapon damage as if they had used \taction{Jump}. After this attack, the character loses the \tstatus{Flight} status.
     
     \textit{Summon}: Gain the conditions \tstatus{Flight} and \telem{Earth} \tstatus{Vulnerable} until the end of the round. 
     

--- a/core/revised/spells.tex
+++ b/core/revised/spells.tex
@@ -6,9 +6,9 @@
 
 	\textit{Fire}, acquired at level 1, costs 8 MP. Roll Fire vs Water, difficulty 0. If you hit, deal 5 x Fire level \telem{Fire}-elemental magical damage to a target.
     
-    \textit{Fira}, acquired at level 19, costs 24 MP. Roll Fire vs Water, difficulty 0. If successful, deal 11 x Fire level magical damage level to a target, or 7 x Fire level magical damage level to a group. This damage is \telem{Fire}-elemental.
+    \textit{Fira}, acquired at level 19, costs 24 MP. Roll Fire vs Water, difficulty 0. If successful, deal 10 x Fire level magical damage level to a target, or 8 x Fire level magical damage level to a group. This damage is \telem{Fire}-elemental.
     
-    \textit{Firaga}, acquired at level 37, costs 58 MP. Roll Fire vs Water, difficulty 0. If successful, deal 17 x Fire level magical damage level to a target, or 10 x Fire level magical damage level to a group. This damage is \telem{Fire}-elemental.
+    \textit{Firaga}, acquired at level 37, costs 58 MP. Roll Fire vs Water, difficulty 0. If successful, deal 16 x Fire level magical damage level to a target, or 11 x Fire level magical damage level to a group. This damage is \telem{Fire}-elemental.
     
     \textit{Meltdown}, acquired at level 55, costs 110 MP. Roll Fire vs Water, difficulty 0. If successful, deal 23 x Fire level \telem{Fire}-elemental magical damage level to a target. Also, if your roll overcomes difficulty 70, inflict the \tstatus{Meltdown} status on the target until the end of the round.
     
@@ -16,9 +16,9 @@
     
     \textit{Blizzard}, acquired at level 1, costs 8 MP. Roll Fire vs Water, difficulty 0. If successful, deal 5 x Fire level \telem{Ice}-elemental magical damage to a target.
     
-    \textit{Blizzara}, acquired at level 19, costs 24 MP. Roll Fire vs Water, difficulty 0. If successful, deal 11 x Fire level magical damage level to a target, or 7 x Fire level magical damage level to a group. This damage is \telem{Ice}-elemental.
+    \textit{Blizzara}, acquired at level 19, costs 24 MP. Roll Fire vs Water, difficulty 0. If successful, deal 12 x Fire level magical damage level to a target, or 6 x Fire level magical damage level to a group. This damage is \telem{Ice}-elemental.
     
-    \textit{Blizzaga}, acquired at level 37, costs 58 MP. Roll Fire vs Water, difficulty 0. If successful, deal 17 x Fire level magical damage level to a target, or 10 x Fire level magical damage level to a group. This damage is \telem{Ice}-elemental.
+    \textit{Blizzaga}, acquired at level 37, costs 58 MP. Roll Fire vs Water, difficulty 0. If successful, deal 18 x Fire level magical damage level to a target, or 9 x Fire level magical damage level to a group. This damage is \telem{Ice}-elemental.
     
     \textit{Freeze}, acquired at level 55, costs 110 MP. Roll Fire vs Water, difficulty 0. If successful, deal 23 x Fire level \telem{Ice}-elemental magical damage level to a target. Also, if your roll overcomes difficulty 70, inflict the \tstatus{Stop} status on the target until the end of the round.
     
@@ -70,7 +70,7 @@
     
     \textit{Waterga}, acquired at level 28, costs 40 MP. Roll Fire vs Water, difficulty 0. If successful, deal 14 x Fire level magical damage level to a target, or 8 x Fire level magical damage level to a group. This damage is \telem{Water}-elemental.
     
-    \textit{Storm}, acquired at level 46, costs 80 MP. Roll Fire vs Water, difficulty 0. If successful, deal 20 x Fire level magical damage level to a target, or 12 x Fire level magical damage level to a group. This damage is \telem{Water}-elemental. Also, if your roll overcomes difficulty 70, inflict the \tstatus{Sleep} status on the targets during this and the next two rounds.
+    \textit{Storm}, acquired at level 46, costs 80 MP. Roll Fire vs Water, difficulty 0. If successful, deal 20 x Fire level magical damage level to a target, or 12 x Fire level magical damage level to a group. This damage is \telem{Water}-elemental. Also, if your roll overcomes difficulty 70, inflict the \tstatus{Curse} status on the targets during this and the next two rounds.
     
     \subsection{Worldly Spells}\label{subsec:black-worldly}
 
@@ -80,7 +80,7 @@
     
     \textit{Quake}, acquired at level 28, costs 43 MP. Roll Fire vs Water, difficulty 0. If successful, deal 14 x Fire level \telem{Earth}-elemental magical damage to all combatants who do not have the \tstatus{Float} or \tstatus{Flight} statuses. This Spell ignores \tstatus{Reflect}.
     
-    \textit{Break}, acquired at level 46, costs 84 MP. Roll Fire vs Water, difficulty 0. If successful, deal 20 x Fire level \telem{Earth}-elemental magical damage level to a target. Also, if your roll overcomes difficulty 70, inflict the \tstatus{Stone} status on the target until the end of the next round.
+    \textit{Break}, acquired at level 46, costs 84 MP. Roll Fire vs Water, difficulty 0. If successful, deal 21 x Fire level \telem{Earth}-elemental magical damage level to a target. Also, if your roll overcomes difficulty 70, inflict the \tstatus{Stone} status on the target until the end of the next round.
     
     \textbf{Shadow Group}: Worldly Spells whose main purpose is to deal Shadow-elemental damage. There are three Shadow spells:
     
@@ -293,23 +293,23 @@
     
     \textbf{Weaken Group}: Subtle Spells whose main purpose is to decrease the damage dealt or endured by the target. Thus, it is a versatile group, possessing a blend of offensive and defensive spells. There are four Weaken Spells:
     
-    \textit{Mental Down}, acquired at level 1, costs 20 MP. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Mental)} status on the target until the end of next round.
+    \textit{Mental Down}, acquired at level 1, costs MP equal to half of caster's level. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Mental)} status on the target until the end of next round.
     
-    \textit{Armor Down}, acquired at level 19, costs 20 MP. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Armor)} status on the target until the end of next round.
+    \textit{Armor Down}, acquired at level 19, costs MP equal to half of caster's level. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Armor)} status on the target until the end of next round.
     
-    \textit{Power Down}, acquired at level 37, costs 50 MP. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Physical)} status on the target until the end of next round.
+    \textit{Power Down}, acquired at level 37, costs MP equal to caster's level. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Physical)} status on the target until the end of next round.
     
-    \textit{Magic Down}, acquired at level 55, costs 50 MP. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Magic)} status on the target until the end of next round.
+    \textit{Magic Down}, acquired at level 55, costs MP equal to caster's level. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Weaken (Magic)} status on the target until the end of next round.
     
     \textbf{Strengthen Group}: Subtle Spells whose main purpose is to increase the damage dealt or endured by the target. Thus, it is a versatile group, possessing a blend of offensive and defensive spells. There are four Strengthen Spells:
     
-    \textit{Mental Up}, acquired at level 1, costs 20 MP. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Mental)} status to the target until the end of next round.
+    \textit{Mental Up}, acquired at level 1, costs MP equal to half of caster's level. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Mental)} status to the target until the end of next round.
 
-    \textit{Armor Up}, acquired at level 19, costs 20 MP. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Armor)} status to the target until the end of next round.
+    \textit{Armor Up}, acquired at level 19, costs MP equal to half of caster's level. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Armor)} status to the target until the end of next round.
     
-    \textit{Power Up}, acquired at level 37, costs 50 MP. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Physical)} status to the target until the end of next round.
+    \textit{Power Up}, acquired at level 37, costs MP equal to caster's level. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Physical)} status to the target until the end of next round.
     
-    \textit{Magic Up}, acquired at level 55, costs 50 MP. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Magic)} status to the target until the end of next round.
+    \textit{Magic Up}, acquired at level 55, costs MP equal to caster's level. Roll Fire vs Water, difficulty 0. If successful, grant the \tstatus{Strengthen (Magic)} status to the target until the end of next round.
     
     \textbf{Flight Group}: Subtle Spells whose main purpose is to deal with winged opponents. With these spells, you can stick a flying opponent to the ground or have an ally fly out of reach of its opponents. There are four Flight Spells:
     
@@ -455,9 +455,9 @@ These more powerful spells begin to reveal the true power of Blue Mage. They are
 
 1--2: \tstatus{Immobilize}, \tstatus{Mute}, \tstatus{Poison}, \tstatus{Meltdown}.
 
-3--4: \tstatus{Blind}, \tstatus{Disable}, \tstatus{Poison}, \tstatus{Slow}.
+3--4: \tstatus{Blind}, \tstatus{Disable}, \tstatus{Curse}, \tstatus{Slow}.
 
-5--6: \tstatus{Confuse}, \tstatus{Slow}, \tstatus{Virus}, \tstatus{Toad}.
+5--6: \tstatus{Curse}, \tstatus{Slow}, \tstatus{Virus}, \tstatus{Toad}.
 
 7--8: \tstatus{Confuse}, \tstatus{Condemn}, \tstatus{Slow}, \tstatus{Poison}.
 
@@ -479,14 +479,16 @@ These more powerful spells begin to reveal the true power of Blue Mage. They are
     
     \textit{Stone Breath} costs 115 MP. Roll Fire vs Water, difficulty 70, against a group. Inflict the \tstatus{Stone} status until the end of the next round on each target hit.
     
-	\textit{Supernova} costs 175 MP. Roll Fire vs Water, difficulty 0. If successful, deal 8 x character level \telem{non}-elemental magical damage to a group. This Spell ignores the \tstatus{Reflect} status.
+	\textit{Supernova} costs 175 MP. Roll (Fire or Water) vs Water, difficulty 70, against the enemy group. Should you hit all targets, regain the MP spent, up to 100 MP, and you may act again. Should you miss at least one target, instead, deal 9 x character level \telem{non}-elemental magical damage to all targets you missed. This Spell ignores the \tstatus{Reflect}, \tstatus{Blind}, \tstatus{Premonition}, \tstatus{Curse}, \tstatus{Shell} and \tstatus{Blink} statuses.
 
 \end{multicols}
 \section{Other Spells}\label{sec:magic-other}
 \begin{multicols}{2}
 
-    These spells give some specific Secondary Jobs some capabilities that complement their skills. The Berserker learn one of these Spells at advanced level, and the Defender may eventually learn one, two or even three of these Spells. These Spells are not a Spell group of and may not be chosen as such.
+    These spells give some specific Jobs some capabilities that complement their skills. The Druid may learn one, The Berserker learn one of these Spells at advanced level, and the Defender may eventually learn one, two or even three of these Spells. These Spells are not a Spell group of and may not be chosen as such.
     
+    \textit{Curse}, acquired at level 1, costs 7 MP. Roll Fire vs Water, difficulty 70. If successful, inflict the \tstatus{Curse} on the target until the end of the round.
+
     \textit{Astra}, acquired at level 30, costs 35 MP. Roll Fire vs Water, difficulty 0. If successful, the target becomes immune to all negative status effects until the end of the round.
     
     \textit{Dispel}, acquired at level 40, costs 60 MP. Roll Fire vs Water, difficulty 40. If successful, the target loses all the positive status effects. If he has Auto-Status or SOS-Status, these effects are disabled until the end of the round. This spell ignores \tstatus{Reflect}.
@@ -679,9 +681,9 @@ These more powerful spells begin to reveal the true power of Blue Mage. They are
 
     1--2: \tstatus{Immobilize}, \tstatus{Mute}, \tstatus{Poison}, \tstatus{Meltdown}.
 
-    3--4: \tstatus{Blind}, \tstatus{Disable}, \tstatus{Poison}, \tstatus{Slow}.
+    3--4: \tstatus{Blind}, \tstatus{Disable}, \tstatus{Curse}, \tstatus{Slow}.
     
-    5--6: \tstatus{Confuse}, \tstatus{Slow}, \tstatus{Virus}, \tstatus{Toad}.
+    5--6: \tstatus{Curse}, \tstatus{Slow}, \tstatus{Virus}, \tstatus{Toad}.
     
     7--8: \tstatus{Confuse}, \tstatus{Condemn}, \tstatus{Slow}, \tstatus{Poison}.
     

--- a/core/revised/squire.tex
+++ b/core/revised/squire.tex
@@ -29,7 +29,7 @@
 \crystal{air}{12pt} & %
 \tspec{Counter Tackle}: Requires Air level 8. Whenever an enemy tries to use the \taction{Escape} action against you, increase his difficulty by 20. \\ 
 \crystal{fire}{12pt} & %
-\tspec{Spell Evasion}: Requires Fire level 10. You may use your \taction{Dodge} reaction to avoid Spells (but not magical attacks). If you do, increase the \taction{Dodge} difficulty by 20. \\
+\tspec{Spell Evasion}: Requires Fire level 10. You may use \taction{Dodge}, \taction{Block} and \taction{Parry} to avoid Spells (but not magical attacks). If you do, increase the difficulty by 20. Spells that target your party still inflict normal effects on your allies and you can only use \taction{Block} or \taction{Parry} when equipped with the correct weapons. \\
 \crystal{fire}{12pt} & %
 \tspec{Weaponcaster}: Requires Fire level 6. Whenever you cast a Spell due to a weapon ability, you may use the weapon’s Offensive Stat, rather than the Fire Stat, to hit (but not deal damage). \\
 \end{jobchoice}
@@ -42,9 +42,9 @@
 \crystal{fire}{12pt} & %
 \tspec{Awareness}: Requires Fire level 16. You gain the Ranged magical action \taction{Awareness}. Do a Fire vs Air, dif 0, attack against all enemies. Your acute senses detect traces of enemy presence. All enemies hit lose the \tstatus{Vanish} status effect.  \\
 \crystal{earth}{12pt} \crystal{water}{12pt} & %
-\tspec{Faith and Bravery}: Requires Earth and Water level 13. Whenever you are under the effects a Weaken status effect, gain a Strengthen status effect. \tstatus{Weaken (Armor)} gives you \tstatus{Strengthen (Physical)}. \tstatus{Weaken (Mental)} gives you \tstatus{Strengthen (Magical)}. \tstatus{Weaken (Physical)} gives you \tstatus{Strengthen (Armor)}. \tstatus{Weaken (Magical)} gives you \tstatus{Strengthen (Mental)}.  \\
+\tspec{Faith and Bravery}: Requires Earth and Water level 13. Whenever you are under the effects a Weaken status effect, gain a Strengthen status effect. \tstatus{Weaken (Armor)} gives you \tstatus{Strengthen (Physical)}. \tstatus{Weaken (Mental)} gives you \tstatus{Strengthen (Magical)}. \tstatus{Weaken (Physical)} gives you \tstatus{Strengthen (Armor)}. \tstatus{Weaken (Magical)} gives you \tstatus{Strengthen (Mental)}. \\
 \crystal{earth}{12pt} \crystal{air}{12pt} & %
-\tspec{Mighty Dodge}: Requires Air and Earth level 13. You may use the \taction{Attack} action as a free action after you succeed with the \taction{Dodge} reaction.  \\
+\tspec{Mighty Dodge}: Requires Air and Earth level 13. You may use the \taction{Attack} action as a free action after you succeed with \taction{Dodge}, \taction{Block} or \taction{Parry}. \\
 \end{jobchoice}
 \end{ffminipage}
 
@@ -56,5 +56,7 @@
 \tspec{Ordered Retreat}:Requires Air and Water level 16. When you succeed with the \taction{Escape} action, treat as if all allies succeeded with a \taction{Escape} action this phase. \\
 \crystal{earth}{12pt} \crystal{air}{12pt} \crystal{fire}{12pt} \crystal{water}{12pt} & %
 \tspec{Graduation}: Requires Earth, Air, Fire and Water level 12. Choose an action of any other Secondary Job.  You gain that action. This ability cannot grant reactions. \\
+\crystal{fire}{12pt} & %
+\tspec{Imbue}: Requires Fire level 18. Gain the quick magical action \taction{Imbue}. With it, you consume a battle item to give a weapon the Imbue (spell) Equipment Effect. This effect allows the charater with the equipped weapon to cast the consumed battle item's spell as an action, without spending MP. All abilities that effect Spell Weave affect Imbue as well. The Imbue property lasts until it is used to cast the spell or \taction{Imbue} is used again on the same weapon. \\
 \end{jobchoice}
 \end{ffminipage}

--- a/core/revised/timemage.tex
+++ b/core/revised/timemage.tex
@@ -3,13 +3,13 @@
 
     \textbf{Representatives}: Time Mage Job (FFV, FFT, FFTA) \pc
 
-    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=6x,mpa=3x,mpc=4x,armor=Light,weapons=Claws / Gloves \\ Light Swords / Knives \\ Staves \\ Wands]
+    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=6x,mpa=2x,mpb=3x,mpc=4x,armor=Light,weapons=Claws / Gloves \\ Light Swords / Knives \\ Staves \\ Wands]
 \end{jobdesc}
 
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\tability{Arcane Studies}: Core Ability acquired at level 1. You can equip \tequip{light armor} and the following weapons: \tequip{Claws / Gloves}; \tequip{Light Swords / Knives}; \tequip{Staves}; \tequip{Wands}. Your HP bonus is 3 times your level, the multiplier increasing by 1 at levels 15, 30 and 60. Your bonus MP is 3 times your level, the multiplier increasing by 1 at level 30. \pc
+\tability{Arcane Studies}: Core Ability acquired at level 1. You are a time mage, and gain the multipliers and equipment choices above. \pc
 
 \begin{jobchoice}
 \crystal{level}{12pt} \crystal{fire}{12pt} & %

--- a/core/revised/warrior.tex
+++ b/core/revised/warrior.tex
@@ -1,0 +1,120 @@
+\begin{jobdesc}[name=pjob-warrior]
+    A focused fighter in heavy armor, specialist in melee combat. Its main stats are Earth and Air, with Water as tertiary stat. Regardless of the Stat you focus, Warriors may work offensively or defensively; they can either focus on causing as much damage as possible or on protecting the group to by weakening their opponent. Regardless of the chosen skills, it is a simple class to play: buy the best possible equipment, and you will have enough HP, damage and defenses to defeat any opponent. \pc
+
+    \textbf{Representatives}: Dragoon Job (FFIII, FFV, FFXI, FFT, FFTA), Uhlan Job (FFXIIZJ), Kain Highwind (FFIV), Cid Highwind (FFVII), Ward Zabac (FFVIII), Freya Crescent (FFIX), Gladiator Job (FFTA), Fighter Job (FFI, FFIII), Warrior Job (FFXI), Adelbert Steiner (FFIX), Auron (FFX), Knight Job (FFIII, FFV, FFT), Leo Cristophe (FFVI), Soldier Job (FFTA), Cyan Garamonde (FFVI), Cloud Strife (FFVII), Squall Leonhart (FFVIII), Tidus (FFX) \pc
+
+    \jobstats[hpa=5x,hpb=6x,hpc=7x,hpd=8x,mpa=0x,mpc=1x,armor=Heavy,weapons=Light Sword/ Knives \\ Claws / Gloves \\ Weapon \& Shield \\ Heavy Weapon \\ Katanas \\ Polearms]
+\end{jobdesc}
+
+\begin{ffminipage}
+{\centering \textbf{Abilities}\par }
+
+\tability{Master of Arms}: Core ability acquired at level 1. You are a warrior, and gain the multipliers and equipment choices above. \pc
+
+\begin{jobchoice}
+\crystal{earth}{12pt} & %
+\tspec{Critical Force}: Requires Earth level 5. Whenever you use an ability that requires an weapon attack and has no special effects on critical hits, you may choose to deal twice weapon damage on critical hits (instead of the ability's damage) and all equipment effects. \\
+\crystal{earth}{12pt} \crystal{air}{12pt} & %
+\tspec{Adroit}: Requires Earth and Air level 3. Whenever you use a Warrior ability other than a weapon attack, you can choose to use either Earth or Air as Offensive Stat. Whenever you acquire an ability that gives you the choice between two Break actions, you gain both Break actions. \\
+\crystal{fire}{12pt} & %
+\tspec{Arc}: Requires Fire level 3. You may add Ranged to your \taction{Attack} actions. You may charge a Slow (1) action (or increase the Slow (X) rating by 1) to add Ranged to any Warrior abilities which require an weapon attack. \\
+\crystal{water}{12pt} & %
+\tspec{Armored Agility}: Requires Water level 3. Once per turn, you may reroll the \taction{Dodge}, \taction{Block} or \taction{Parry} reactions. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+\noindent\tability{Power Attack}: Core Ability acquired at level 1. You earn one of the three actions below: \pc
+
+\begin{jobchoice}[header=false]
+\crystal{level}{12pt} & %
+\taction{Jump} is a Quick action. Using it, you jump an incredible height and gain the \tstatus{Flight} status. In your next action, you dive on a target, discarding the initiative die and attacking with your weapon. If you hit, inflict 150\% weapon damage. After the attack, you lose the \tstatus{Flight} status. Deal twice weapon damage instead of 150\% if you wield a Polearm. \\
+\crystal{level}{12pt} & %
+\taction{Mighty Strike} is a Quick action. Attacking with all your might, without preparation or any worry about accuracy, you deliver a devastating attack. Perform an attack with your weapon but increasing the difficulty by 30. Your attack does twice weapon damage, plus all the equipment effects as usual. \\
+\crystal{level}{12pt} & %
+\taction{Minus Strike} is a Slow (1) physical action. When using it, focus your chi energy to perform an Earth vs Earth attack, difficulty 40, against a target. If successful, this action causes \telem{Cut}-elemental damage equal to the lowest between 10 times your Armor value or (your max HP - your current HP). Don’t add the singles digit to damage. This action ignores the \tstatus{Strengthen (Physical)} status and may not deal over 999 damage. \\
+\end{jobchoice} \pc
+
+\begin{jobchoice}
+\crystal{air}{12pt} & %
+\tspec{Shield Break}: Requires Air level 7. Choose and gain one Break action: 
+
+\taction{Armor Break}, a Quick physical action that weakens the resistance of the target. Perform an Air vs Earth attack, difficulty 50, to inflict the \tstatus{Weaken (Armor)} status on the target until the end of round; or 
+
+\taction{Mental Break}, a Quick physical action that weakens the spirit of the target. Perform an Air vs Water attack, difficulty 50, to inflict the \tstatus{Weaken (Mental)} status on the target until the end of round. \\
+\crystal{water}{12pt} & %
+\tspec{Dirty Fighting}: Requires Water level 5. You gain Quick action \taction{Dirty Fighting} You throw sand in the eyes of the opponent, attack their genitals or distract them in any way. Perform an weapon attack to deal half weapon damage, and until the end of next round, the target cannot use any reactions unless he uses an Interrupt action to do so. \\
+\crystal{fire}{12pt} & %
+\tspec{Pommel Strike}: You gain the Quick action \taction{Pommel Strike}. You attack your opponent with your weapon’s hilt at a time and place where he doesn’t expect. Do an attack roll with your weapon, dealing no damage. If the target is charging a Slow action, he loses it. \\
+\crystal{earth}{12pt} \crystal{air}{12pt} & %
+\tspec{Weapon Specialist}: Requires Earth and Air level 5. Reduce by 10 the difficulty of \taction{Mighty Strike}. In addition, your \taction{Jump} attacks deal twice weapon damage, regardless of the equipped weapon. You may use your Magical Armor instead of Armor value to determine \taction{Minus Strike} and \taction{Dragon Breath}'s damage. \\
+\end{jobchoice}
+\end{ffminipage}
+
+\begin{ffminipage}
+    \noindent\tability{Blacksmith}: Core Ability acquired at level 15. Whenever you or an ally buy a weapon or armor without Equipment Effects, you may destroy a weapon or armor of the same Armor type or Weapon Group to give the new weapon or armor one of the destroyed's Equipment Effects. You may destroy two identical weapons or armors to use this ability either to enhance a weapon or armor with Equipment Effects or to give the ability from a different Armor type or Weapon Group. This ability may not give weapon abilities to armor, give armor abilities to weapons, nor create weapons or armors with more than 2 Equipment Effects, or 3 Equipment Effects if one of them is \textbf{Spell Weave}. \pc
+        
+    \begin{jobchoice}
+    \crystal{earth}{12pt} & %
+    \tspec{Weapon Break}: Requires Earth level 7. Choose and gain one Break action: 
+    
+    \taction{Power Break}, a Quick physical action that weakens the the muscle power of the target. Perform an Earth vs Air attack, difficulty 50, to inflict the \tstatus{Weaken (Physical)} status on the target until the end of round; or 
+    
+    \taction{Magic Break}, a Quick physical action that weakens the magical power of the target. Perform an Earth vs Fire attack, difficulty 50, to inflict the \tstatus{Weaken (Magic)} status on the target until the end of round. \\
+    \crystal{water}{12pt} & %
+    \tspec{Dirty Fighting}: Requires Water level 5. You gain Quick action \taction{Dirty Fighting} You throw sand in the eyes of the opponent, attack their genitals or distract them in any way. Perform an weapon attack to deal half weapon damage, and until the end of next round, the target cannot use any reactions unless he uses an Interrupt action to do so. \\
+    \crystal{fire}{12pt} & %
+    \tspec{Quadra Slam}: Requires Earth level 6 and Water level 8. You gain the Slow (4) physical action \taction{Quadra Slam}. When using it, you move with incredible speed, striking four consecutive attacks with your weapon with just one action. You may split the attacks between any number of enemies. Each deal half weapon damage and the first and second strike each target receives ignores its Armor. \\
+    \crystal{earth}{12pt} \crystal{air}{12pt} & %
+    \tspec{Guardbreak}: Requires Air level 6 and Fire level 8. You gain the Quick physical action \taction{Guardbreak}.You deal a sudden strike to the opponent, disrupting its defensive stance. Perform an weapon attack to deal half weapon damage, and if the target is delaying any actions, it loses the delayed initiative dice. \taction{Guardbreak} may also be used as an interrupt. \\
+    \end{jobchoice}
+    \end{ffminipage}
+    
+    \begin{ffminipage}
+        \noindent\tability{Double Cut}: Core Ability acquired at level 24. You gain the Slow (5) action \taction{Double Cut}. With it, do two attacks with your weapon in quick succession at the same target, dealing weapon damage and effects. This ability may achieve critical hits, causing double damage. You may substitute one or both attacks for a Break action. \pc
+            
+        \begin{jobchoice}
+        \crystal{earth}{12pt} \crystal{fire}{12pt} & %
+        \tspec{Slash All}: Requires Earth and Fire level 11. \taction{Slash-All} is a Slow (2) action. Moving with speed, you can unleash an attack with your weapon against all enemies. Each enemy takes damage equal to your weapon damage, plus all equipment effects. \\
+        \crystal{air}{12pt} \crystal{water}{12pt} & %
+        \tspec{Blade Beam}: Requires Air and Water level 11. \taction{Blade Beam} is a Ranged Slow (2) action. You shoot a wave of chi energy at a target, performing an attack with your weapon that deals half weapon damage, Puncture-elemental. If it succeeds, you deal Puncture-elemental damage to all other enemies, equal to the original target' Armor value. All damage dealt by this attack, both by the first and secondary strikes, ignores Armor and the \tstatus{Protect} status. \\
+        \crystal{fire}{12pt} \crystal{water}{12pt} & %
+        \tspec{Mastery of Destruction}: Requires Fire and Water level 10. You may increase the charge time by 3 when performing one of your known Break actions to target all enemies, or to increase the duration of the \tstatus{Weaken} status inflicted by one round. \\
+        \end{jobchoice}
+    \end{ffminipage}
+        
+        \begin{ffminipage}
+            \noindent\tability{Dragon Power}: Core Ability acquired at level 42. Choose one of the following abilities: \pc
+
+            \begin{jobchoice}[header=false]
+            \crystal{level}{12pt} & %
+            \tspec{Dragon Horn} After you perform \taction{!Jump}'s attack, you may, as an interrupt, use an action to repeat the attack against the same target. This second attack happens before you lose the Flight Status. \\
+            \crystal{level}{12pt} & %
+            \tspec{Dragon Breath} You gain the Slow (3) physical action \taction{Dragon Breath}. This action allows you to use the weakness of your enemy against itself. If you have success in an Air vs Air attack, difficulty 40, the target is dealt \telem{Crush}-elemental damage equal to the lowest between 10 times your Armor value or (target’s max HP – target’s current HP). Don’t add the singles digit to damage. This action ignores the \tstatus{Strengthen (Physical)} status and may not deal over 999 damage. \\
+            \crystal{level}{12pt} & %
+            \tspec{Dragon Scales} After you sucessfully perform a reaction against a physical action, the enemy that performed the action loses HP equal to your Armor value. After you sucessfully perform a reaction against a Spell or magical action, the enemy that performed the action loses HP equal to your Magical Armor value. In any case, ignore the enemy's Armor, Magical Armor and all status effects. \\
+            \end{jobchoice} \pc
+                        
+            \begin{jobchoice}
+            \crystal{earth}{12pt} & %
+            \tspec{Lethal Blow}: Requires Earth level 16. When using \taction{Dragon Breath} or \taction{Minus Strike}, reduce the damage by the target's Armor before applying 999 damage limit, instead of after. Your \taction{Dragon Scales} always use the highest between Armor or Magical Armor everytime it is triggered. You may perform a \taction{Attack} action as an interrupt after using \tspec{Dragon Horn}. \\
+            \crystal{air}{12pt} & %
+            \tspec{Dragon Blood}: Requires Air level 16. Whenever an enemy attack reduces your HP to 25\% of its maximum value or less, you may use a \taction{Power Attack} ability as a free action. \\
+            \crystal{fire}{12pt} \crystal{water}{12pt} & %
+            \tspec{Mastery of Destruction}: Requires Fire and Water level 12. Your \taction{Armor Break} and \taction{Mental Break} inflict \tstatus{Meltdown} until the end of next round on enemies with \tstatus{Weaken(Armor)} or \tstatus{Weaken(Mental)} statuses. Your \taction{Power Break} inflict \tstatus{Disable} until the end of next round on enemies with \tstatus{Weaken(Physical)} or \tstatus{Weaken(Magic)} statuses. Your \taction{Magic Break} inflict \tstatus{Mute} until the end of next round on enemies with \tstatus{Weaken(Physical)} or \tstatus{Weaken(Magic)} statuses. These durations may not be enhanced by \tspec{Mastery of Destruction}. \\
+            \end{jobchoice}
+        \end{ffminipage}
+            
+        \begin{ffminipage}
+            \noindent\tability{Unbreakable}: Core Ability acquired at level 60. You become immune to \tstatus{Weaken}-type status effects. \pc
+                
+            \begin{jobchoice}
+            \crystal{air}{12pt} & %
+            \tspec{Finishing Touch}: Requires Air level 20. You gain the Slow (5) action \taction{Finishing Touch}. Make two weapon attacks, difficulty 70, against the target. If both attacks are successful, inflict the \tstatus{Stone} status. If the target is immune to \tstatus{Stone} or if only one attack is successful, you deal double weapon damage. If the enemy is not immune to \tstatus{Fatal}-type statuses and one or both blows land a critical hit, reduce your opponent to 0 HP. Treat this last effect as a \tstatus{Fatal}-type status. \\
+            \crystal{fire}{12pt} & %
+            \tspec{Shock}: Requires Fire level 20. You gain the Ranged Slow (5) physical action \taction{Shock}. This action releases a burst of Chi that affects all your enemies. Perform an Earth vs Fire attack, difficulty 40. Each affected opponent suffers twice weapon damage. \\
+            \crystal{water}{12pt} & %
+            \tspec{Iaijutsu}: Requires Water level 20. You gain the Slow (5) physical action \taction{Cleave}. You go through your opponents with a sharp blow. Make an Air vs Earth attack, difficulty 70, against all your enemies. Instantly reduce to 0 HP all affected opponents. This effect counts as a \tstatus{Fatal}-type status. All enemies left alive (either immune to \tstatus{Fatal} or due to a failed attack) suffer half weapon damage. \\
+            \end{jobchoice}
+            \end{ffminipage}
+    

--- a/core/revised/whitemage.tex
+++ b/core/revised/whitemage.tex
@@ -3,13 +3,13 @@
 
     \textbf{Representatives}: Porom (FFIV), Rosa Farrell (FFIV), White Mage Job (FFI, FFIII, FFV, FFX-2, FFXI, FFT, FFTA) \pc
 
-    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=6x,mpa=3x,mpc=4x,armor=Light,weapons=Claws / Gloves \\ Staves \\ Wands]
+    \jobstats[hpa=3x,hpb=4x,hpc=5x,hpd=6x,mpa=2x,mpb=3x,mpc=4x,armor=Light,weapons=Claws / Gloves \\ Staves \\ Wands]
 \end{jobdesc}
 
 \begin{ffminipage}
 {\centering \textbf{Abilities}\par }
 
-\tability{Arcane Devotion}: Core Ability acquired at level 1. You can equip \tequip{light armor} and the following weapons: \tequip{Claws / Gloves}; \tequip{Staves}; \tequip{Wands}. You gain the \tspellgroup{Healing} Spell group. Your HP bonus is 3 times your level, the multiplier increasing by 1 at levels 15, 30 and 60. Your MP bonus is 3 times your level, the multiplier increasing by 1 at level 30. \pc
+\tability{Arcane Devotion}: Core Ability acquired at level 1. You are a white mage, and gain the multipliers and equipment choices above. \pc
 
 \begin{jobchoice}
 \crystal{level}{12pt} \crystal{fire}{12pt} & %


### PR DESCRIPTION
Includes change to:
Adept.tex : updated to the errata version
Alchemist.tex: updated to the playtest packet version
Archer.tex: updated to the playtest packet version
Artist.tex: updated to the errata version
berserker.tex: updated to the playtest packet version
blackmage.tex: updated to the errata version
defender.tex: initial type, plus updated to the errata version
druid.tex: updated to the errata version
engine.tex: minor english changes, new optional rule and updated with new "as interrupt" rule idea plus changes in examples for changed abilities and included mentions to "charge time"
fencer.tex: updated to the errata version
freelancer.tex: minor wording changes
monk.tex: updated to the errata version