### PR TITLE
b-401: several hotfixes

### DIFF
--- a/core/revised.tex
+++ b/core/revised.tex
@@ -13,11 +13,11 @@
 \raggedcolumns{}
 \setlength{\parskip}{0pt plus0pt minus0pt}
 \setlength{\baselineskip}{13.6pt plus0pt minus0pt}
-\singlespacing
+\singlespacing{}
 
 \title{Core Rulebook}
 \edition{Remastered}
-\version{4.0.0} % chktex 8
+\version{4.0.1 Prerelease \datestamp} % chktex 8
 \titleimage{cover-swordguy}
 
 \robustify{\cftsecfont}

--- a/core/revised/archer.tex
+++ b/core/revised/archer.tex
@@ -44,7 +44,7 @@
     \crystal{air}{12pt} \crystal{fire}{12pt} & %
     \tspec{Patience Shot}: Requires Air and Fire level 10. When using a damage-dealing action thats not a Spell, you can increase its charge time by 4 to increase the damage dealt by 50\% weapon damage. \\
     \crystal{water}{12pt} & %
-    \tspec{Marked Quarry}: Requires Water level 13. Requires Water level 13. Once per round, when you hit a single target attack, reduce the difficulty of the next attack targeting the same character by 30, to a minimum of 0. \\
+    \tspec{Marked Quarry}: Requires Water level 13. Once per round, when you hit a single target attack, reduce the difficulty of the next attack targeting the same character by 30, to a minimum of 0. \\
     \crystal{earth}{12pt} \crystal{air}{12pt} & %
     \tspec{Wing Aim}: Requires Earth level 6 and Air level 10. You gain the Slow (1) action \taction{Wing Aim}. Using it, you shoot the target’s wings. Attack with your weapon, difficulty 70. If successful, the target loses the \tstatus{Float} and \tstatus{Flight} statuses, if any, and cannot gain them until the end of the next round. \\
     \tabjobsep%

--- a/core/revised/csv-input/weapons.csv
+++ b/core/revised/csv-input/weapons.csv
@@ -51,7 +51,7 @@ Blood Hammer,37,5484,10 x,\tability{Improved Critical}
 Demon Slicer,37,5170,10 x,\tfxkiller{Demon}
 Scimitar / War Hammer,46,6203,13 x,
 Cold Steel,46,9022,13 x,\tfxtouch{Slow}
-Soul Saber,46,9587,13 x,\teffect{Ability}
+Soul Saber,46,9587,13 x,\teffect{Piercing}
 "Enhancer ",55,Rare,14 x,"\tfxauto{Strengthen: Magic}
 \tfxauto{Strengthen: Physical}"
 Mage Killer,55,Rare,14 x,"\tfxauto{Shell}

--- a/core/revised/dervish.tex
+++ b/core/revised/dervish.tex
@@ -23,7 +23,7 @@
     \crystal{fire}{12pt} \crystal{water}{12pt} & %
     \tspec{Two-Weapon Defense}: Requires Fire level 9 and Water level 5. You gain the reaction \taction{Double Parry}. Use when hit by a Melee \tatk{physical} attack. Do an (the greater of Air or Earth) vs Earth attack, difficulty 40. If successful, you ignore the attack’s effects. \\
     \tabjobsep%
-    \multicolumn{2}{p{\textwidth}}{\tability{Deadly Accuracy}: Core Ability acquired at level 35. After rolling an attack, you may reduce or increase the d100 result by 1.} \\
+    \multicolumn{2}{p{\textwidth}}{\tability{Deadly Accuracy}: Core Ability acquired at level 35. Once per action, after rolling an attack, you may reduce or increase the d100 result by 1.} \\
     \tabjobspec{}
     \crystal{air}{12pt} & %
     \tspec{Deep Cut}: Requires Air level 15. When you attain a critical hit with an action that deals damage, ignore the target’s ARM and MARM\@. \\

--- a/core/revised/engine.tex
+++ b/core/revised/engine.tex
@@ -133,19 +133,19 @@ In addition, if the Slow action require you to prepare your action beyond phase 
 Reactions occur when the character uses specific abilities. They interrupt other actions and must be resolved before the first action’s effects are applied. To use a reaction, the character can spend an initiative dice with the current phase’s value, use a delayed action or even perform an interruption. Some reactions are free actions. A character may wait to see if an action is successful or not before declaring his reaction.
 
 \subsection{Attacks and Rolls in Combat}\label{subsec:attacks}
-All rolls in combat (attack rolls, reactions, Spells, etc.) have the following characteristics: One Offensive Stat, one Defensive Stat and a difficulty. For example, the \taction{Attack} action using a Bow is an Air (Offensive stat) vs Air (Defensive stat) attack, difficulty 40. The roll is as follows: The player will roll 1d100 and add his Offensive Stat’s value. He will be successful if the result is higher than difficulty + the target’s Defensive Stat’s value. If target choose to not resist the action, it is always successful, unless the action says otherwise.
+All rolls in combat (Reactions, Spells, other attacks, etc.) have the following characteristics: One Offensive Stat, one Defensive Stat and a difficulty. For example, the \taction{Attack} action using a Bow is an Air (Offensive stat) vs Air (Defensive stat) attack, difficulty 40. The roll is as follows: The player will roll 1d100 and add his Offensive Stat’s value. He will be successful if the result is higher than difficulty + the target’s Defensive Stat’s value. If target choose to not resist the action, it is always successful, unless the action says otherwise.
 
 If the attack is against a group (be it ally’s or enemy’s), the player must perform only one roll. After adding the d100 roll to Offensive Stat’s value, it should compare it separately with the sum of difficulty + Defensive Stat’s value of each target and may be successful against only part of the opponents.
 
 If the attack deals damage or recovers HP or MP, the d100’s unit digit will be added to the damage dealt or value healed, unless the attack says otherwise. Finally, if a character re-rolls an attack, either because he can re-roll one of his attacks, or because the target can force his opponent to re-roll his attacks, the character can look at the results and choose the best (or be forced to choose the worst).
 
-Each attack, except Spells, may be Ranged or Melee. All Ranged attacks are noted as such; every non-Ranged attack is Melee. Flying enemies may not be hit by Melee attacks, unless the attacker is also Flying. Spells and Reactions aren't neither Ranged nor Melee and may target Flying enemies normally.
+Each attack, except Spells, may be Ranged or Melee. All Ranged attacks are noted as such; every non-Ranged attack is Melee. Flying enemies may not be hit by Melee attacks, unless the attacker is also Flying. Spells and Reactions are neither Ranged nor Melee and may target Flying enemies normally.
 
 \subsection{Basic Actions and Reactions}\label{subsec:basicactions}
 All characters can perform the following actions, regardless of equipment, Job or Abilities.
 
 \subsubsection{\taction{Attack}}
-Quick action. If the character is unarmed, perform an Earth vs Earth attack, difficulty 70. The damage is physical, \telem{Crush}-elemental, equal to Earth level. If it is equipped with a weapon, use the weapon’s Offensive and Defensive Stats, difficulty 40, and deal weapon damage. The Wealth and Items section, below, has more details about the weapons between pages 94 to 107. This action may score critical hits, dealing twice damage.
+Quick action. If the character is unarmed, perform an Earth vs Earth attack, difficulty 70. The damage is physical, \telem{Crush}-elemental, equal to Earth level. If it is equipped with a weapon, use the weapon’s Offensive and Defensive Stats, difficulty 40, and deal weapon damage. The Wealth and Items section, below, has more details about the weapons between pages 94 to 107. This action may score critical hits, dealing double damage.
 
 \subsubsection{\taction{Dodge}}
 Reaction. Use when suffering a physical attack. Roll Air vs Earth, difficulty 70. If successful, you don’t suffer the attack’s effects.
@@ -160,7 +160,7 @@ Quick action. No roll needed. You use a drawn item or replace the equipped weapo
 Quick action. Roll Air vs Air, difficulty 40. If successful, you run away from combat. Use the opponent with the highest Air Stat as the target of this action.
 
 \subsection{Critical Hits}
-Various actions can score critical hits. Unless the equipped weapon or the Ability says otherwise, critical hits double the damage. To score a critical hit, the roll result should be two identical numbers (100, 99, 88, 77, 66, 55, etc.) and the attack must be successful. If an action does not state that it might achieve critical hits, rolling identical numbers does no extra effect.
+Only actions that explicitly mention their critical hit effect can score them. To score a critical hit, the roll result should be two identical numbers (100, 99, 88, 77, 66, 55, etc.) and the attack must be successful. If an action does not state that it might achieve critical hits, rolling identical numbers does no extra effect.
 
 \begin{center}
     \adjincludegraphics[width=0.35\textwidth]{block-suplex-train}

--- a/core/revised/freelancer.tex
+++ b/core/revised/freelancer.tex
@@ -21,10 +21,10 @@
             Increase your HP bonus multiplier by 1 at all levels & 2 & May be chosen twice \\
             Increase your MP bonus multiplier by 1 at all levels & 2 & May be chosen twice \\
             \tability{Awakened}, \tability{Natural Domain}, \tability{Arcane Devotion} core abilities & 2 & \\
-            Pick a job's first ability that grants spell groups & 2 & Other than \tability{Arcane Devotion} \\
-            Pick a job's second or later ability that grants spell groups & 1 & Other than \tability{Arcane Devotion} \\
-            Pick a specialty from an ability you already have a specialty from & 2 & \\
-            Pick a core ability or specialty not listed above & 1 & \\ \bottomrule
+            First ability that grants spell groups & 2 & Other than \tability{Arcane Devotion} \\
+            Second or later ability that grants spell groups & 1 & Other than \tability{Arcane Devotion} \\
+            Specialty from an ability you already have a specialty from & 2 & \\
+            Core ability or specialty not listed above & 1 & \\ \bottomrule
         \end{tabular}%
     } \\
     \multicolumn{2}{p{\textwidth}}{\tability{JP UP}: Core Ability acquired at level 16. Gain 1 Job Point. You may spend any Job Points you have stored immediately.} \\

--- a/core/revised/generated/wpn-weapons-with-shields.tex
+++ b/core/revised/generated/wpn-weapons-with-shields.tex
@@ -17,7 +17,7 @@
 \tabwpnrow[name={Demon Slicer},mlevel={37},cost={5170},damage={10 x},effect={\tfxkiller{Demon}}]
 \tabwpnrow[name={Scimitar / War Hammer},mlevel={46},cost={6203},damage={13 x},effect={}]
 \tabwpnrow[name={Cold Steel},mlevel={46},cost={9022},damage={13 x},effect={\tfxtouch{Slow}}]
-\tabwpnrow[name={Soul Saber},mlevel={46},cost={9587},damage={13 x},effect={\teffect{Ability}}]
+\tabwpnrow[name={Soul Saber},mlevel={46},cost={9587},damage={13 x},effect={\teffect{Piercing}}]
 \tabwpnrow[name={Enhancer},mlevel={55},cost={Rare},damage={14 x},effect={\tfxauto{Strengthen: Magic}\newline{}\tfxauto{Strengthen: Physical}}]
 \tabwpnrow[name={Mage Killer},mlevel={55},cost={Rare},damage={14 x},effect={\tfxauto{Shell}\newline{}\teffect{Arcane Damage}}]
 \tabwpnrow[name={Dancing Saber},mlevel={55},cost={Rare},damage={14 x},effect={\tfxtouch{Confuse}\newline{}Add Air level to damage}]

--- a/core/revised/inv-equip-effects.tex
+++ b/core/revised/inv-equip-effects.tex
@@ -7,7 +7,7 @@
         Arcane Destruction & Full damage is dealt to the MP in addition to the HP \\
         Arcane Focus (Spell) & You can use this weapon to cast the listed spell, spending MP as usual.  You do not need to know the spell. \\
         Auto – (Status)\textsuperscript{1} & Grants the (status) while you're equipped with this item. \\
-        Critical Spell (Spell) & When you score a critical hit, instead of doubling the damage, cast the Spell as a free action without spending MP\@{}. You don’t need to know the Spell to do this. \\
+        Critical Spell (Spell) & Once per phase, when you score a critical hit, instead of doubling the damage, cast the Spell as a free action without spending MP\@{}. You don’t need to know the Spell to do this.\\
         \telem{(\textit{Element})} Damage & Every time this weapon hits, you may choose to do its normal damage type or \telem{(\textit{element})} damage. \\
         Improved Critical & Critical hits happen even if the attack didn’t overcome the difficulty. \\
         HP Drain & Half damage dealt (before accounting for ARM or MARM) is recovered as HP\@{}. \\

--- a/core/revised/inv-equip-effects.tex
+++ b/core/revised/inv-equip-effects.tex
@@ -30,6 +30,6 @@
 \begin{enumerate}
     \item Auto-\tstatus{Reraise} and SOS-\tstatus{Reraise} effects works only once per combat.
     \item Whenever Spell Weave is used to cast a Spell whose effects heal HP, MP and/or status effects, the weapon is broken and irretrievably lost after casting the Spell.
-    \item Whenever Status Touch or Status Strike inflict the Condemn or Stone statuses, those last until the end of next round.
+    \item Whenever Status Touch or Status Strike inflict the Weaken(Speed), Slow, Condemn or Stone statuses, those last until the end of next round.
 \end{enumerate}
 \end{footnotesize}

--- a/core/revised/inv-equip-effects.tex
+++ b/core/revised/inv-equip-effects.tex
@@ -30,6 +30,6 @@
 \begin{enumerate}
     \item Auto-\tstatus{Reraise} and SOS-\tstatus{Reraise} effects works only once per combat.
     \item Whenever Spell Weave is used to cast a Spell whose effects heal HP, MP and/or status effects, the weapon is broken and irretrievably lost after casting the Spell.
-    \item Whenever Status Touch or Status Strike inflict the Weaken(Speed), Slow, Condemn or Stone statuses, those last until the end of next round.
+    \item Whenever Status Touch or Status Strike inflict the Weaken: Speed, Slow, Condemn or Stone statuses, those last until the end of next round.
 \end{enumerate}
 \end{footnotesize}

--- a/core/revised/monk.tex
+++ b/core/revised/monk.tex
@@ -28,6 +28,7 @@
     \taction{Doton} is a Ranged Slow (3) \tatk{magical} action.  Using it, you invoke elemental spirits. Do a Fire vs Earth attack, difficulty 40. If successful, deal 4x Fire level Earth-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Poison} status until the end of the next round. At level 20 or greater, critical hits also inflict the \tstatus{Virus} status until the end of the next round. \\
     \crystal{level}{12pt} & %
     \taction{Fuuton} is a Ranged Slow (3) magical action. Using it, you invoke elemental spirits. Do a Fire vs Air attack, difficulty 40. If successful, deal 4x Fire level Air-elemental damage on a target. This ability can achieve critical hits; in this case, besides the damage, the target receives the \tstatus{Blind} status until the end of the next round. At level 20 or greater, critical hits also inflict the \tstatus{Confuse} status until the end of the next round. \\
+    Regardless of the chosen Jutsu, at level 15 the damage becomes 6x Fire level, at level 22 the damage becomes 8x Fire Level, at level 31 the damage becomes 11x Fire Level and at level 40 the damage becomes 14x Fire level. \\
     \tabjobspec{}
     \crystal{air}{12pt} \crystal{fire}{12pt} & %
     \tspec{Elan}: Requires Air level 4 and Fire level 6. Your Jutsu targets a group instead of just one target. \\

--- a/core/revised/performances.tex
+++ b/core/revised/performances.tex
@@ -31,7 +31,8 @@
     \textit{Fatal Flamenco} is a level 5 dance. Perform four Water vs Earth attacks, difficulty 50, against random enemies. For each success, you deal weapon physical damage. This action may target the same enemy more than once.
     
     \textit{Dirty Dancing} is a level 5 dance. Perform a Water vs Fire attack, difficulty 70. If successful, inflict the \tstatus{Meltdown} status on a target until the end of next round.
-	\textit{Forbidden Dance} is a level 5 dance. Perform a Water vs Water attack, difficulty 70. If successful, roll 1d10 for each enemy in the opposing group. Inflict a status to each enemy hit until the end of the next round, according to the die roll: 1 --- \tstatus{Blind}; 2 --- \tstatus{Condemn}; 3 --- \tstatus{Confuse}; 4 --- \tstatus{Disable}; 5 --- \tstatus{Poison}; 6 --- \tstatus{Berserk}; 7 --- \tstatus{Immobilize}; 8 --- \tstatus{Stop}; 9 --- \tstatus{Toad}; 10 --- \tstatus{Zombie}.
+    
+    \textit{Forbidden Dance} is a level 5 dance. Perform a Water vs Water attack, difficulty 70. If successful, roll 1d10 for each enemy in the opposing group. Inflict a status to each enemy hit until the end of the next round, according to the die roll: 1 --- \tstatus{Blind}; 2 --- \tstatus{Condemn}; 3 --- \tstatus{Confuse}; 4 --- \tstatus{Disable}; 5 --- \tstatus{Poison}; 6 --- \tstatus{Berserk}; 7 --- \tstatus{Immobilize}; 8 --- \tstatus{Stop}; 9 --- \tstatus{Toad}; 10 --- \tstatus{Zombie}.
     
 
     \subsection{Song}\label{subsec:perf-song}

--- a/core/revised/spells.tex
+++ b/core/revised/spells.tex
@@ -527,7 +527,7 @@ These more powerful spells begin to reveal the true power of Blue Mage. They are
     
     \textit{Stone Breath} costs 115 MP\@. Roll Fire vs Water, difficulty 70, against a group. Inflict the \tstatus{Stone} status until the end of the next round on each target hit.
     
-	\textit{Supernova} costs 175 MP\@. Roll (Fire or Water) vs Water, difficulty 70, against the enemy group. Should you hit all targets, regain the MP spent, up to 100 MP, and you may act again. Should you miss at least one target, instead, deal 9 x character level \telem{non}-elemental magical damage to all targets you missed. This Spell ignores the \tstatus{Reflect}, \tstatus{Blind}, \tstatus{Premonition}, \tstatus{Curse}, \tstatus{Shell} and \tstatus{Blink} statuses.
+	\textit{Supernova} costs 175 MP\@. Roll (Fire or Water) vs Water, difficulty 70, against the enemy group. Should you hit all targets, regain the MP spent, up to 100 MP, and you may act again. Should you miss at least one target, instead, deal 9 x character level \telem{non}-elemental magical damage to all targets you missed. You should roll this even if the targets want to be hit. This Spell ignores the \tstatus{Reflect}, \tstatus{Blind}, \tstatus{Premonition}, \tstatus{Curse}, \tstatus{Shell} and \tstatus{Blink} statuses.
 
 \end{multicols}
 \section{Other Spells}\label{sec:magic-other}

--- a/core/revised/spells.tex
+++ b/core/revised/spells.tex
@@ -479,7 +479,7 @@ These more powerful spells begin to reveal the true power of Blue Mage. They are
 
     \textit{Death Claw} costs 110 MP\@. Roll Fire vs Water, difficulty 80. If successful, the target's HP is reduced to the d100’s singles digit, considering 0 as 10. Treat this as a \tstatus{Gravity} status effect.
     
-    \textit{Earth Shake} costs 67 MP\@. Roll Fire vs Water, difficulty 0. Roll Fire vs Water, difficulty 0. If successful, deal 13 x Fire level \telem{Earth}-elemental magical damage level to a group. This Spell ignores the \tstatus{Reflect} status and automatically fails against targets under the \tstatus{Float} or \tstatus{Flight} status effects.
+    \textit{Earth Shake} costs 67 MP\@. Roll Fire vs Water, difficulty 0. If successful, deal 13 x Fire level \telem{Earth}-elemental magical damage level to a group. This Spell ignores the \tstatus{Reflect} status and automatically fails against targets under the \tstatus{Float} or \tstatus{Flight} status effects.
     
     \textit{Electrocute} costs 85 MP\@. Roll Fire vs Water, difficulty 0. If successful, deal 13 x Fire level \telem{Lightning}-elemental magical damage level to a group. This Spell ignores the \tstatus{Reflect} status.
     

--- a/core/revised/tab-status.tex
+++ b/core/revised/tab-status.tex
@@ -29,13 +29,13 @@
     \tstatus{Weaken: Magic} & Negative & Weaken & Deal 25\% less magical damage. \\
     \tstatus{Weaken: Mental} & Negative & Weaken & Reduce MARM by half. \\
     \tstatus{Weaken: Physical} & Negative & Weaken & Deal 25\% less physical damage. \\
-    \tstatus{Weaken: Speed} & Negative & Weaken & Increase each initiative die value by 1. Increase the charge time of all Slow actions by 1. \\
+    \tstatus{Weaken: Speed} & Negative & Weaken & At the start of phase 1, increase each initiative die value by 1. Increase the charge time of all Slow actions by 1. \\
     \tstatus{Regen} & Positive & Strengthen & At each round's end, heal HP equal to 10\% of your max HP\@. \\
     \tstatus{Strengthen: Armor} & Positive & Strengthen & Increase ARM by half. \\
     \tstatus{Strengthen: Magic} & Positive & Strengthen & Deal 25\% more magical damage. \\
     \tstatus{Strengthen: Mental} & Positive & Strengthen & Increase MARM by half. \\
     \tstatus{Strengthen: Physical} & Positive & Strengthen & Deal 25\% more physical damage. \\
-    \tstatus{Strengthen: Speed} & Positive & Strengthen & Reduce each initiative die value by 1. Reduce the charge time of all Slow actions by 1, to a minimum of 1. \\
+    \tstatus{Strengthen: Speed} & Positive & Strengthen & At the start of phase 1, reduce each initiative die value by 1. Reduce the charge time of all Slow actions by 1, to a minimum of 1. \\
     \tstatus{Float} & Positive & Flight & Float about two feet off the ground, causing effects that depend on the ground to not affect you. \\
     \tstatus{Flight} & Positive & Flight & Only Ranged attacks or Spells may hit you. Your melee attacks may hit targets with any Flight status unless they specifically may not target Float status. \\
     \tstatus{Slow} & Negative & Time & Roll one fewer initiative die. \\

--- a/core/revised/warrior.tex
+++ b/core/revised/warrior.tex
@@ -47,8 +47,6 @@
     \taction{Power Break}, a Quick physical action that weakens the the muscle power of the target. Perform an Earth vs Air attack, difficulty 50, to inflict the \tstatus{Weaken (Physical)} status on the target until the end of round; or 
     
     \taction{Magic Break}, a Quick physical action that weakens the magical power of the target. Perform an Earth vs Fire attack, difficulty 50, to inflict the \tstatus{Weaken (Magic)} status on the target until the end of round. \\
-    \crystal{water}{12pt} & %
-    \tspec{Dirty Fighting}: Requires Water level 5. You gain Quick action \taction{Dirty Fighting} You throw sand in the eyes of the opponent, attack their genitals or distract them in any way. Perform an weapon attack to deal half weapon damage, and until the end of next round, the target cannot use any reactions unless he uses an Interrupt action to do so. \\
     \crystal{earth}{12pt} \crystal{water}{12pt} & %
     \tspec{Quadra Slam}: Requires Earth level 6 and Water level 8. You gain the Slow (4) physical action \taction{Quadra Slam}. When using it, you move with incredible speed, striking four consecutive attacks with your weapon with just one action. You may split the attacks between any number of enemies. Each deal half weapon damage and the first and second strike each target receives ignores its Armor. \\
     \crystal{air}{12pt} \crystal{fire}{12pt} & %
@@ -76,7 +74,7 @@
     \crystal{air}{12pt} & %
     \tspec{Dragon Blood}: Requires Air level 16. Whenever an enemy attack reduces your HP to 25\% of its maximum value or less, you may use a \taction{Power Attack} ability as a free action. \\
     \crystal{fire}{12pt} \crystal{water}{12pt} & %
-    \tspec{Mastery of Destruction}: Requires Fire and Water level 12. Your \taction{Armor Break} and \taction{Mental Break} inflict \tstatus{Meltdown} until the end of next round on enemies with \tstatus{Weaken: Armor} or \tstatus{Weaken: Mental} statuses. Your \taction{Power Break} inflict \tstatus{Disable} until the end of next round on enemies with \tstatus{Weaken: Physical} or \tstatus{Weaken: Magic} statuses. Your \taction{Magic Break} inflict \tstatus{Mute} until the end of next round on enemies with \tstatus{Weaken: Physical} or \tstatus{Weaken: Magic} statuses. These durations may not be enhanced by \tspec{Mastery of Destruction}. \\
+    \tspec{Scorching Strikes}: Requires Fire and Water level 12. Your \taction{Armor Break} and \taction{Mental Break} inflict \tstatus{Meltdown} until the end of next round on enemies with \tstatus{Weaken: Armor} or \tstatus{Weaken: Mental} statuses. Your \taction{Power Break} inflict \tstatus{Disable} until the end of next round on enemies with \tstatus{Weaken: Physical} or \tstatus{Weaken: Magic} statuses. Your \taction{Magic Break} inflict \tstatus{Mute} until the end of next round on enemies with \tstatus{Weaken: Physical} or \tstatus{Weaken: Magic} statuses. These durations may not be enhanced by \tspec{Mastery of Destruction}. \\
     \tabjobsep%
     \multicolumn{2}{p{\textwidth}}{\tability{Unbreakable}: Core Ability acquired at level 60. You become immune to \tstatus{Weaken}-type status effects.} \\
     \tabjobspec{}


### PR DESCRIPTION
Did 10 assorted hotfixes for 4.0.1

Weaver adds:
closes #285 (marked quarry)
closes #304 (freelancer)
closes #303 (jutsu)
closes #300 (dervish)
closes #296 (earth shake)
closes #289 (supernova)
closes #282 (warrior)
closes #278 (warrior)


