### PR TITLE
w-wmagic: w-magic wasn't a \taction

### DIFF
--- a/core/revised/wizard.tex
+++ b/core/revised/wizard.tex
@@ -54,7 +54,7 @@
     \\
     \tabjobspec{}
     \crystal{air}{12pt} & %
-    \tspec{Twincast}: Requires Air level 18. You gain the Slow (2) action \tability{W-Magic}. Using it, you cast two Spells with one action. \tability{W-Magic} may not be used to cast spells whose base MP costs, added, exceed 150. \\
+    \tspec{Twincast}: Requires Air level 18. You gain the Slow (2) action \taction{W-Magic}. Using it, you cast two Spells with one action. \taction{W-Magic} may not be used to cast spells whose base MP costs, added, exceed 150. \\
     \crystal{level}{12pt} \crystal{water}{12pt} & %
     \tspec{Forbidden Arcana}: Requires Water level 18 and character level 64. Choose an Arcane Mysteries Specialty of any Mage Job. You gain this Ability, even if you do not meet the requirements. \\
 \end{tabjob}


### PR DESCRIPTION
I think I forgot to make a PR for this. This change is still outstanding.